### PR TITLE
Add tests for serializeErrorDefault function in server.test.tsx

### DIFF
--- a/server.test.tsx
+++ b/server.test.tsx
@@ -3,6 +3,10 @@ import { describe, it } from "@std/testing/bdd";
 
 import { Client } from "@udibo/juniper/client";
 import { createServer } from "@udibo/juniper/server";
+import { simulateEnvironment } from "@udibo/juniper/utils/testing";
+import { HttpError } from "@udibo/http-error";
+
+import { serializeErrorDefault } from "./_server.tsx";
 
 describe("createServer", () => {
   it("should return 404 for a non-existent route", async () => {
@@ -86,5 +90,51 @@ describe("createServer", () => {
     const testRes = await server.request("http://localhost/test");
     assertEquals(testRes.status, 200);
     assertEquals(await testRes.text(), "Server Route");
+  });
+});
+
+describe("serializeErrorDefault", () => {
+  it("should pass through non-Error values unchanged", () => {
+    const value = { foo: "bar" };
+    const result = serializeErrorDefault(value);
+    assertEquals(result, value);
+  });
+
+  it("should serialize generic Error with message and stack in development", () => {
+    using _env = simulateEnvironment({ "APP_ENV": null });
+    const err = new Error("Oops");
+    const result = serializeErrorDefault(err) as Record<string, unknown>;
+    assertEquals(result.__type, "Error");
+    assertEquals(result.message, "Oops");
+    assertEquals(typeof result.stack, "string");
+    assertEquals(result.__subType, undefined);
+  });
+
+  it("should omit stack outside development", () => {
+    using _env = simulateEnvironment({ "APP_ENV": "production" });
+    const err = new Error("No stack");
+    const result = serializeErrorDefault(err) as Record<string, unknown>;
+    assertEquals(result.__type, "Error");
+    assertEquals(result.message, "No stack");
+    assertEquals(result.stack, undefined);
+  });
+
+  it("should set __subType for Error subclasses", () => {
+    const err = new TypeError("Wrong type");
+    const result = serializeErrorDefault(err) as Record<string, unknown>;
+    assertEquals(result.__type, "Error");
+    assertEquals(result.__subType, "TypeError");
+    assertEquals(result.message, "Wrong type");
+  });
+
+  it("should serialize HttpError with RFC7807 fields", () => {
+    const err = new HttpError(400, "Bad request");
+    const result = serializeErrorDefault(err) as Record<string, unknown>;
+    assertEquals(result.__type, "Error");
+    assertEquals(result.__subType, "HttpError");
+    assertEquals(result.status, 400);
+    const detailOrMessage = (result as Record<string, unknown>)["detail"] ??
+      result.message;
+    assertEquals(detailOrMessage, "Bad request");
   });
 });


### PR DESCRIPTION
This improves the test coverage for the server by covering the default error serialization function.