### PR TITLE
Remove deploy job for deno deploy classic

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,28 +59,6 @@ jobs:
         run: deno task test:example
       - name: Run minimal template tests
         run: deno task test:minimal --parallel
-  deploy:
-    name: Deploy to Deno Deploy
-    needs: [test]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-          cache: true
-      - name: Build for production
-        run: deno task build-prod
-      - name: Deploy to Deno Deploy
-        uses: denoland/deployctl@v1
-        with:
-          project: juniper
-          entrypoint: ./example/main.ts
   publish:
     name: Publish to JSR
     needs: [test]


### PR DESCRIPTION
The new version of deno deploy builds the application and deploys the application separately from github workflows.