### PR TITLE
Update example services and tests to support test parallelization

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Run example tests
-        run: deno task test:example
+        run: deno task test:example --parallel
       - name: Run minimal template tests
         run: deno task test:minimal --parallel
   publish:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - Formatting issues can be automatically fixed with `deno fmt`.
 - For stubs and spys, prefer using explicit resource management over manually
   adding try/finally with restore call.
+- Never disable sanitization to get tests to pass.
 
 ## Style
 

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@^1.0.23": "1.0.23",
     "jsr:@std/collections@^1.1.3": "1.1.3",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fs@^1.0.19": "1.0.20",
     "jsr:@std/http@1": "1.0.21",
@@ -79,6 +80,9 @@
     "@std/collections@1.1.3": {
       "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
     },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
+    },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
@@ -111,6 +115,8 @@
       "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
       "dependencies": [
         "jsr:@std/assert",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },

--- a/example/routes/api/users.test.ts
+++ b/example/routes/api/users.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals, assertExists } from "@std/assert";
 import { sortBy } from "@std/collections/sort-by";
-import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { FakeTime } from "@std/testing/time";
 import { generate as generateUUIDv7 } from "@std/uuid/unstable-v7";
 
@@ -66,7 +66,6 @@ describe("/api/users", () => {
         displayName: "Robert G. (updated)",
       });
     });
-    afterAll(() => userService.close());
 
     it("should return a list of users", async () => {
       const res = await server.request("/api/users");
@@ -211,8 +210,6 @@ describe("/api/users", () => {
   });
 
   describe("GET /:id", () => {
-    afterEach(() => userService.close());
-
     it("should return a specific user if found", async () => {
       const newUserData = createSampleUserInput();
       const createdUser = await userService.create(newUserData);
@@ -262,8 +259,6 @@ describe("/api/users", () => {
   });
 
   describe("POST /", () => {
-    afterEach(() => userService.close());
-
     it("should create a new user and return it", async () => {
       const newUserData = createSampleUserInput({
         username: "apipostuser",
@@ -402,8 +397,6 @@ describe("/api/users", () => {
   });
 
   describe("PUT /:id", () => {
-    afterEach(() => userService.close());
-
     it("should update an existing user and return it", async () => {
       const createdUser = await userService.create(
         createSampleUserInput({ username: "putuseroriginal" }),
@@ -579,8 +572,6 @@ describe("/api/users", () => {
   });
 
   describe("PATCH /:id", () => {
-    afterEach(() => userService.close());
-
     it("should partially update an existing user and return it", async () => {
       const createdUser = await userService.create(
         createSampleUserInput({ username: "patchuseroriginal" }),
@@ -744,8 +735,6 @@ describe("/api/users", () => {
   });
 
   describe("DELETE /:id", () => {
-    afterEach(() => userService.close());
-
     it("should delete an existing user and return a confirmation", async () => {
       const createdUser = await userService.create(
         createSampleUserInput({ username: "deleteuser" }),

--- a/example/routes/blog/index.test.tsx
+++ b/example/routes/blog/index.test.tsx
@@ -4,25 +4,29 @@ import { generate as generateUUIDv7 } from "@std/uuid/unstable-v7";
 
 import { server } from "@/main.ts";
 import { postService } from "@/services/post.ts";
-import type { NewPost } from "@/services/post.ts";
+import type { NewPost, Post } from "@/services/post.ts";
 
 describe("GET /blog (index)", () => {
-  let testAuthorId: string;
+  let testPost: Post;
 
   beforeAll(async () => {
-    testAuthorId = generateUUIDv7();
-
-    const testPost: NewPost = {
+    const testAuthorId = generateUUIDv7();
+    const testPostData: NewPost = {
       title: "Test Blog Post",
       content: "This is test content for the blog post listing page.",
       authorId: testAuthorId,
     };
 
-    await postService.create(testPost);
+    testPost = await postService.create(testPostData);
   });
 
   afterAll(async () => {
-    await postService.close();
+    try {
+      await postService.delete(testPost.id);
+    } catch {
+      // ignore cleanup errors
+    }
+    postService.close();
   });
 
   it("should return HTML with blog posts listing", async () => {

--- a/example/routes/blog/main.test.tsx
+++ b/example/routes/blog/main.test.tsx
@@ -1,10 +1,14 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { afterAll, describe, it } from "@std/testing/bdd";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 
 import { server } from "@/main.ts";
 import { postService } from "@/services/post.ts";
 
 describe("GET /blog", () => {
+  beforeAll(async () => {
+    await postService.open();
+  });
+
   afterAll(() => {
     postService.close();
   });

--- a/example/services/post.ts
+++ b/example/services/post.ts
@@ -17,9 +17,20 @@ export type Post = z.infer<typeof PostSchema>;
 export type NewPost = Omit<Post, "id" | "createdAt" | "updatedAt">;
 export type PostPatch = Partial<Post> & { id: string };
 
-export const postService = new Service({
-  name: "post",
-  schema: PostSchema,
-  uniqueIndexes: [],
-  indexes: ["authorId", "updatedAt"],
-});
+export interface PostServiceOptions {
+  keyspace?: string;
+}
+
+export class PostService extends Service<Post> {
+  constructor(options?: PostServiceOptions) {
+    super({
+      name: "post",
+      schema: PostSchema,
+      uniqueIndexes: [],
+      indexes: ["authorId", "updatedAt"],
+      keyspace: options?.keyspace,
+    });
+  }
+}
+
+export const postService = new PostService();


### PR DESCRIPTION
This is accomplished by adding the option to pass a keyspace to the services. The keyspace is prefixed to all service keys so that the kv database is sharded by keyspace. Test cases operating in different keyspaces will not impact each other.