### PR TITLE
Fix how build imports env utils

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -5,7 +5,7 @@ import * as path from "@std/path";
 import { toText } from "@std/streams";
 import * as esbuild from "esbuild";
 
-import { isProduction } from "@udibo/juniper/utils/env";
+import { isProduction } from "./utils/env.ts";
 
 import {
   type GeneratedRoute,


### PR DESCRIPTION
This works but for some reason deno publish doesn't like it.

```
[16](https://github.com/udibo/juniper/actions/runs/20649139495/job/59291032520#step:5:317)
Checking for slow types in the public API...
warning[unanalyzable-dynamic-import]: unable to analyze dynamic import
Warning:   --> /home/runner/work/juniper/juniper/src/dev.ts:16:29
   | 
16 |     builder = (await import(projectRoot + "/build.ts")).builder;
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ the unanalyzable dynamic import
   | 

  info: after publishing this package, imports from the local import map / package.json do not work
  info: dynamic imports that can not be analyzed at publish time will not be rewritten automatically
  info: make sure the dynamic import is resolvable at runtime without an import map / package.json

Publishing @udibo/juniper@0.0.1 ...
error: Failed to publish @udibo/juniper@0.0.1

Caused by:
    Failed to publish @udibo/juniper at 0.0.1: failed to build module graph: export 'utils/env' not found in jsr:@udibo/juniper
        at file:///build.ts:8:30
```