### PR TITLE
fix: drop redundant release:false rules that overrode patch matches

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,19 +7,14 @@
       {
         "preset": "angular",
         "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "revert": true, "release": "patch" },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
           { "type": "revert", "release": "patch" },
           { "type": "build", "scope": "deps", "release": "patch" },
-          { "type": "chore", "scope": "deps", "release": "patch" },
-          { "type": "docs", "release": false },
-          { "type": "style", "release": false },
-          { "type": "refactor", "release": false },
-          { "type": "test", "release": false },
-          { "type": "build", "release": false },
-          { "type": "ci", "release": false },
-          { "type": "chore", "release": false }
+          { "type": "chore", "scope": "deps", "release": "patch" }
         ]
       }
     ],


### PR DESCRIPTION
## Summary

Fix a bug in `.releaserc.json` where the prior PR's `chore(deps)` rule was being silently overridden by a redundant catch-all `release: false` rule, preventing dependency-bump commits from triggering a release. Also restores breaking-change and revert detection that was unintentionally dropped from the default release rules.

## Background

After [#78] landed, the merged `chore(deps): release prior dependency updates (#77)` commit still produced "no release." Reading semantic-release's [analyze-commit.js](https://github.com/semantic-release/commit-analyzer/blob/master/lib/analyze-commit.js) reveals the cause: `releaseRules` are not first-match-wins. The analyzer iterates **every** matching rule and accumulates the highest release type — but a matching rule with `release: false` clears the release type and stops iteration.

For a `chore(deps): ...` commit, two rules matched:

1. `{ type: "chore", scope: "deps", release: "patch" }` → set releaseType to patch
2. `{ type: "chore", release: false }` → cleared it back to undefined and stopped

The catch-all `release: false` entries were also redundant. When `releaseRules` is provided, it replaces the defaults entirely — any commit type without a matching rule already produces no release. The `release: false` rules weren't blocking anything; they were stomping on legitimate patch matches.

A separate problem: replacing the defaults also dropped the special-property rules `{ breaking: true, release: "major" }` and `{ revert: true, release: "patch" }`, so `BREAKING CHANGE` footers and revert commits weren't being detected as major/patch either.

## Changes

- Remove the redundant `{ type: <x>, release: false }` rules for `docs`, `style`, `refactor`, `test`, `build`, `ci`, and `chore`. The absence of a matching rule already produces no release.
- Add `{ "breaking": true, "release": "major" }` and `{ "revert": true, "release": "patch" }` so breaking changes and reverts are detected (they were dropped when custom `releaseRules` replaced the defaults).
- Keep the explicit allow-list: `feat` → minor, `fix` / `perf` / `revert` / `build(deps)` / `chore(deps)` → patch.

## Testing

- On merge to `main`, semantic-release re-analyzes all commits since 0.4.0. Expected: `chore(deps): release prior dependency updates (#77)` now matches the patch rule, and this PR's `fix:` commit also matches → 0.4.1 release with changelog entries for the prior dep bumps and this fix.
