### PR TITLE
fix: honor redirectDocument() in data-mode redirects

### DIFF
--- a/src/_client.tsx
+++ b/src/_client.tsx
@@ -270,9 +270,21 @@ async function fetchServerData(
 
   const responseType = response.headers.get("X-Juniper");
   if (responseType === "redirect") {
-    const location = (await response.json()).location;
+    const redirectData = await response.json();
+    const location = redirectData.location;
     const currentUrl = new URL(globalThis.location.href);
     const redirectUrl = new URL(location, currentUrl);
+
+    // `redirectDocument()` requests a full-page navigation (e.g. to a
+    // server-only route the client router can't render). Hand it to the
+    // browser instead of attempting a client-side route transition, which
+    // would 404 on the unmatched route or mis-handle its response.
+    if (redirectData.reloadDocument) {
+      delay(0).then(() => {
+        globalThis.location.assign(redirectUrl.href);
+      });
+      return undefined;
+    }
 
     // If redirecting to the same location, do a browser reload instead
     if (redirectUrl.href === currentUrl.href) {

--- a/src/_server.tsx
+++ b/src/_server.tsx
@@ -749,13 +749,21 @@ export function createHandlers<
             dataOrResponse.status >= 300 && dataOrResponse.status < 400 &&
             location
           ) {
+            // `redirectDocument()` marks a redirect that must be followed as a
+            // full-page navigation (e.g. to a server-only route the client
+            // router can't render), not a client-side route transition. React
+            // Router signals it with this header; relay it to the client so it
+            // can hand the navigation to the browser.
+            const reloadDocument =
+              dataOrResponse.headers.get("X-Remix-Reload-Document") === "true";
             for (const [key, value] of dataOrResponse.headers.entries()) {
               const lowerKey = key.toLowerCase();
               if (
                 lowerKey !== "location" &&
                 lowerKey !== "content-type" &&
                 lowerKey !== "content-length" &&
-                lowerKey !== "set-cookie"
+                lowerKey !== "set-cookie" &&
+                lowerKey !== "x-remix-reload-document"
               ) {
                 c.header(key, value);
               }
@@ -767,7 +775,9 @@ export function createHandlers<
               c.header("Set-Cookie", cookie, { append: true });
             }
             c.header("X-Juniper", "redirect");
-            return c.json({ location });
+            return c.json(
+              reloadDocument ? { location, reloadDocument } : { location },
+            );
           }
           return dataOrResponse;
         }

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -1,6 +1,11 @@
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { Outlet, useLoaderData, useParams } from "react-router";
+import {
+  Outlet,
+  redirectDocument,
+  useLoaderData,
+  useParams,
+} from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 
 import type { RouteLoaderArgs } from "./mod.ts";
@@ -766,6 +771,35 @@ describe("redirect header preservation", () => {
 
     const data = await res.json();
     assertEquals(data, { location: "/dashboard" });
+  });
+
+  it("flags a redirectDocument() redirect so the client navigates the full page", async () => {
+    const client = new Client({
+      path: "/",
+      main: { default: () => <div>Home</div> },
+    });
+
+    const server = createServer(import.meta.url, client, {
+      path: "/",
+      main: {
+        // A full-page redirect to a server-only route the client router
+        // cannot render (the OAuth2 authorize/callback case).
+        loader: () => Promise.resolve(redirectDocument("/auth/login")),
+      },
+    });
+
+    const res = await server.request("http://localhost/", {
+      headers: { "X-Juniper-Route-Id": "/" },
+    });
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("X-Juniper"), "redirect");
+    // The internal reload-document header is not leaked as a response header;
+    // the intent travels in the JSON body so the client can act on it.
+    assertEquals(res.headers.get("X-Remix-Reload-Document"), null);
+
+    const data = await res.json();
+    assertEquals(data, { location: "/auth/login", reloadDocument: true });
   });
 
   it("should preserve multiple Set-Cookie headers from redirect response", async () => {


### PR DESCRIPTION
## Summary

`redirectDocument()` (React Router's marker for "follow this redirect as a full-page navigation, not a client-side route transition") was silently ignored in Juniper's data-request flow. React Router documents `redirectDocument` as working in data mode — which is the mode Juniper uses — so this is a gap in Juniper's redirect handling.

It matters whenever a loader/action redirects to a **server-only route** (a URL with no client route — e.g. an OAuth2 `/authorize` or `/auth/callback` endpoint, or any handler mounted outside the client route tree). Today such a redirect is attempted as a client-side route transition, which either 404s on the unmatched route or mis-parses the target's response. The only reason it sometimes appears to work is React Router's unmatched-route fallback, which is non-deterministic.

## Root cause

`handleDataRequest` in `_server.tsx` serializes any `3xx + Location` loader/action response as `c.json({ location })` with an `X-Juniper: redirect` header. The client (`_client.tsx`) reads only `location` and does a client-side `throw redirect(location)` — it never inspects the document-redirect marker, so `redirectDocument()`'s intent is dropped.

## Changes

- **Server (`_server.tsx`)**: detect React Router's `X-Remix-Reload-Document` marker on the redirect response and relay it as `{ location, reloadDocument: true }` (the internal header itself is no longer copied onto the response). Normal redirects are unchanged — the body stays `{ location }`.
- **Client (`_client.tsx`)**: when `reloadDocument` is set, perform a full-page navigation (`globalThis.location.assign(...)`) instead of a client-side route transition. Normal and same-URL redirects are unchanged.

## Testing

- Added a server test asserting a `redirectDocument()` redirect serializes as `{ location, reloadDocument: true }` with `X-Juniper: redirect`, and that the internal `X-Remix-Reload-Document` header is not leaked as a response header.
- Existing redirect tests (which assert the `{ location }` shape for normal redirects) still pass; server + client test suites green; `deno task check` passes.
- Verified end-to-end in a downstream app: a sign-in action that `redirectDocument()`s into a server-only OAuth2 authorize/callback chain now performs a deterministic full-page navigation (the browser follows the `302` chain) instead of parking on the unmatched route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)