### PR TITLE
test: re-enable op and resource sanitization

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -176,6 +176,10 @@
       "run": true
     }
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "allowScripts": {
     "allow": ["npm:esbuild@0.27.2"],
     "deny": [

--- a/example/deno.json
+++ b/example/deno.json
@@ -55,6 +55,10 @@
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
     "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "env": true,

--- a/src/deno.json
+++ b/src/deno.json
@@ -65,6 +65,10 @@
     "jsxImportSource": "react",
     "jsxImportSourceTypes": "@types/react"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "net": true,

--- a/templates/minimal/deno.json
+++ b/templates/minimal/deno.json
@@ -43,6 +43,10 @@
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "env": true,

--- a/templates/tailwindcss/deno.json
+++ b/templates/tailwindcss/deno.json
@@ -47,6 +47,10 @@
     "@tailwindcss/postcss": "npm:@tailwindcss/postcss@^4.3.0",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "env": true,

--- a/templates/tanstack/deno.json
+++ b/templates/tanstack/deno.json
@@ -46,6 +46,10 @@
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
     "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "env": true,

--- a/tutorials/blog/deno.json
+++ b/tutorials/blog/deno.json
@@ -44,6 +44,10 @@
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },
+  "test": {
+    "sanitizeOps": true,
+    "sanitizeResources": true
+  },
   "permissions": {
     "serve": {
       "env": true,


### PR DESCRIPTION
## Summary

Deno 2.8 changed the default test behavior to no longer sanitize ops and resources. This PR restores the previous (stricter) behavior so that resource and op leaks in tests continue to fail loudly rather than slipping by unnoticed.

## Changes

- Add a `test` block with `sanitizeOps: true` and `sanitizeResources: true` to every `deno.json`:
  - workspace root (`deno.json`)
  - `src/deno.json`
  - `example/deno.json`
  - `templates/minimal/deno.json`
  - `templates/tailwindcss/deno.json`
  - `templates/tanstack/deno.json`
  - `tutorials/blog/deno.json`

## Testing

Configuration-only change — no source behavior is affected. Existing test suites continue to run under the restored sanitization defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)