### PR TITLE
feat(example): make the demo mobile friendly

### DIFF
--- a/example/components/CodeBlock.tsx
+++ b/example/components/CodeBlock.tsx
@@ -16,7 +16,7 @@ export function CodeBlock({
       <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-3">
         {title}
       </h3>
-      <pre className="text-sm text-slate-300 font-mono overflow-x-auto">
+      <pre className="text-sm text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
         {children}
       </pre>
     </div>

--- a/example/routes/blog/[id]/edit.tsx
+++ b/example/routes/blog/[id]/edit.tsx
@@ -58,16 +58,16 @@ export default function EditPost({
               className="w-full px-4 py-3 bg-slate-700/50 border border-slate-600 rounded-lg text-slate-100 placeholder-slate-400 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 resize-none"
             />
           </div>
-          <div className="flex gap-4">
+          <div className="flex flex-col sm:flex-row gap-3">
             <button
               type="submit"
-              className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-lg transition-colors disabled:opacity-50"
+              className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-lg transition-colors disabled:opacity-50 w-full sm:w-auto"
             >
               Save Changes
             </button>
             <Link
               to={`/blog/${post.id}`}
-              className="px-6 py-3 border border-slate-600 text-slate-300 hover:text-slate-100 hover:border-slate-500 rounded-lg transition-colors inline-flex items-center"
+              className="px-6 py-3 border border-slate-600 text-slate-300 hover:text-slate-100 hover:border-slate-500 rounded-lg transition-colors inline-flex items-center justify-center w-full sm:w-auto"
             >
               Cancel
             </Link>

--- a/example/routes/blog/[id]/index.tsx
+++ b/example/routes/blog/[id]/index.tsx
@@ -26,7 +26,7 @@ export default function BlogPost({
 
       <article>
         <header className="mb-8 pb-6 border-b border-slate-700/50">
-          <h1 className="text-4xl font-bold text-slate-100 mb-4 leading-tight">
+          <h1 className="text-2xl sm:text-4xl font-bold text-slate-100 mb-4 leading-tight">
             {post.title}
           </h1>
           <div className="text-slate-500 flex gap-4 items-center flex-wrap">

--- a/example/routes/blog/create.tsx
+++ b/example/routes/blog/create.tsx
@@ -54,16 +54,16 @@ export default function CreatePost() {
               placeholder="Write your post content..."
             />
           </div>
-          <div className="flex gap-4">
+          <div className="flex flex-col sm:flex-row gap-3">
             <button
               type="submit"
-              className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-lg transition-colors disabled:opacity-50"
+              className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-lg transition-colors disabled:opacity-50 w-full sm:w-auto"
             >
               Publish
             </button>
             <Link
               to="/blog"
-              className="px-6 py-3 border border-slate-600 text-slate-300 hover:text-slate-100 hover:border-slate-500 rounded-lg transition-colors inline-flex items-center"
+              className="px-6 py-3 border border-slate-600 text-slate-300 hover:text-slate-100 hover:border-slate-500 rounded-lg transition-colors inline-flex items-center justify-center w-full sm:w-auto"
             >
               Cancel
             </Link>

--- a/example/routes/blog/index.tsx
+++ b/example/routes/blog/index.tsx
@@ -52,7 +52,7 @@ export default function BlogIndex({
 
   return (
     <div>
-      <div className="mb-8 flex justify-between items-start">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-start">
         <div>
           <h2 className="text-2xl font-bold text-slate-100 mb-2">Blog Posts</h2>
           <p className="text-slate-400">
@@ -61,7 +61,7 @@ export default function BlogIndex({
         </div>
         <Link
           to="/blog/create"
-          className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-xl transition-all hover:scale-105"
+          className="px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-semibold rounded-xl transition-all hover:scale-105 text-center whitespace-nowrap sm:text-left"
         >
           Write a Post
         </Link>
@@ -130,7 +130,7 @@ export default function BlogIndex({
           </div>
         )}
 
-      <div className="mt-8 flex items-center justify-between">
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-sm text-slate-400">
           Showing newest posts first
         </div>

--- a/example/routes/features/data/fetcher.tsx
+++ b/example/routes/features/data/fetcher.tsx
@@ -54,10 +54,10 @@ export default function FetcherActionDemo() {
         shouldn't change the URL.
       </p>
 
-      <div className="bg-slate-800/50 rounded-xl p-8 border border-slate-700 mb-6">
+      <div className="bg-slate-800/50 rounded-xl p-6 sm:p-8 border border-slate-700 mb-6">
         <div className="text-center mb-8">
           <div
-            className={`text-7xl font-bold mb-2 transition-all ${
+            className={`text-4xl sm:text-6xl lg:text-7xl font-bold mb-2 transition-all ${
               isSubmitting ? "text-slate-500 scale-95" : "text-emerald-400"
             }`}
           >

--- a/example/routes/features/errors/main.tsx
+++ b/example/routes/features/errors/main.tsx
@@ -51,7 +51,7 @@ export function ErrorBoundary(
         <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-3">
           Example Code
         </h3>
-        <pre className="text-sm text-slate-300 font-mono overflow-x-auto">
+        <pre className="text-sm text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
         {`import { HttpError } from "@udibo/juniper";
 
 export function ErrorBoundary({

--- a/example/routes/features/errors/nested/index.tsx
+++ b/example/routes/features/errors/nested/index.tsx
@@ -10,7 +10,7 @@ export default function NestedErrorIndex() {
         <h3 className="text-sm font-semibold text-slate-400 uppercase tracking-wide mb-3">
           Route Structure
         </h3>
-        <pre className="text-sm text-slate-300 font-mono overflow-x-auto">
+        <pre className="text-sm text-slate-300 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`routes/features/errors/nested/
 ├── main.tsx      ← Has ErrorBoundary (this file)
 ├── child.tsx     ← Throws error, NO ErrorBoundary

--- a/example/routes/features/index.test.tsx
+++ b/example/routes/features/index.test.tsx
@@ -16,7 +16,7 @@ describe("FeaturesIndex route", () => {
     render(<Stub />);
 
     screen.getByRole("heading", { name: "Explore Juniper Features" });
-    screen.getByText(/Select a feature from the sidebar/);
+    screen.getByText(/Select a feature from the navigation/);
   });
 
   it("should have a link to start with routing", () => {

--- a/example/routes/features/index.tsx
+++ b/example/routes/features/index.tsx
@@ -8,7 +8,7 @@ export default function FeaturesIndex() {
         Explore Juniper Features
       </h2>
       <p className="text-slate-400 max-w-md mx-auto mb-8">
-        Select a feature from the sidebar to see it in action. Each example
+        Select a feature from the navigation to see it in action. Each example
         demonstrates a different capability of the Juniper framework.
       </p>
       <div className="flex gap-4 justify-center">

--- a/example/routes/features/main.test.tsx
+++ b/example/routes/features/main.test.tsx
@@ -1,6 +1,7 @@
 import "@udibo/juniper/utils/global-jsdom";
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { assertEquals } from "@std/assert";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, it } from "@std/testing/bdd";
 
 import { createRoutesStub } from "@udibo/juniper/utils/testing";
@@ -63,5 +64,31 @@ describe("FeaturesLayout route", () => {
 
     screen.getByRole("link", { name: "Error Boundary" });
     screen.getByRole("link", { name: "SSR Errors" });
+  });
+
+  it("should render a collapsed mobile nav toggle that controls the nav", () => {
+    const Stub = createRoutesStub([featuresMain]);
+    render(<Stub />);
+
+    const toggle = screen.getByRole("button", { name: "Browse features" });
+    assertEquals(toggle.getAttribute("aria-expanded"), "false");
+    assertEquals(toggle.getAttribute("aria-controls"), "feature-nav");
+  });
+
+  it("should toggle the mobile nav open and closed when clicked", () => {
+    const Stub = createRoutesStub([featuresMain]);
+    render(<Stub />);
+
+    const toggle = screen.getByRole("button", { name: "Browse features" });
+    fireEvent.click(toggle);
+
+    const openToggle = screen.getByRole("button", { name: "Hide features" });
+    assertEquals(openToggle.getAttribute("aria-expanded"), "true");
+
+    fireEvent.click(openToggle);
+    const closedToggle = screen.getByRole("button", {
+      name: "Browse features",
+    });
+    assertEquals(closedToggle.getAttribute("aria-expanded"), "false");
   });
 });

--- a/example/routes/features/main.tsx
+++ b/example/routes/features/main.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
 import { Link, Outlet, useLocation } from "react-router";
 
@@ -124,9 +125,50 @@ function getActiveFeaturePath(pathname: string): string | undefined {
     .sort((a, b) => b.length - a.length)[0];
 }
 
+function FeatureNav(
+  { activeFeaturePath, onNavigate }: {
+    activeFeaturePath?: string;
+    onNavigate?: () => void;
+  },
+) {
+  return (
+    <div className="space-y-6">
+      {featureGroups.map((group) => (
+        <div key={group.title}>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
+            {group.title}
+          </h3>
+          <ul className="space-y-1">
+            {group.features.map((feature) => {
+              const isActive = feature.path === activeFeaturePath;
+              return (
+                <li key={feature.path}>
+                  <Link
+                    to={feature.path}
+                    onClick={onNavigate}
+                    aria-current={isActive ? "page" : undefined}
+                    className={`block px-3 py-2 rounded-lg transition-colors ${
+                      isActive
+                        ? "bg-emerald-500/10 text-emerald-400 border-l-2 border-emerald-400"
+                        : "text-slate-300 hover:text-emerald-400 hover:bg-slate-800/50"
+                    }`}
+                  >
+                    {feature.name}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function FeaturesLayoutShell({ children }: { children: ReactNode }) {
   const location = useLocation();
   const activeFeaturePath = getActiveFeaturePath(location.pathname);
+  const [navOpen, setNavOpen] = useState(false);
 
   return (
     <div>
@@ -142,37 +184,37 @@ function FeaturesLayoutShell({ children }: { children: ReactNode }) {
         </nav>
       </header>
 
-      <div className="grid lg:grid-cols-[280px_1fr] gap-8">
-        <aside className="space-y-6">
-          {featureGroups.map((group) => (
-            <div key={group.title}>
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
-                {group.title}
-              </h3>
-              <ul className="space-y-1">
-                {group.features.map((feature) => {
-                  const isActive = feature.path === activeFeaturePath;
-                  return (
-                    <li key={feature.path}>
-                      <Link
-                        to={feature.path}
-                        className={`block px-3 py-2 rounded-lg transition-colors ${
-                          isActive
-                            ? "bg-emerald-500/10 text-emerald-400 border-l-2 border-emerald-400"
-                            : "text-slate-300 hover:text-emerald-400 hover:bg-slate-800/50"
-                        }`}
-                      >
-                        {feature.name}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
-        </aside>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[280px_1fr] lg:gap-8">
+        <div>
+          <button
+            type="button"
+            onClick={() => setNavOpen((open) => !open)}
+            aria-expanded={navOpen}
+            aria-controls="feature-nav"
+            className="flex w-full items-center justify-between gap-2 rounded-lg border border-slate-700/50 bg-slate-800/50 px-4 py-3 text-sm font-semibold uppercase tracking-wider text-slate-300 transition-colors hover:text-emerald-400 lg:hidden"
+          >
+            {navOpen ? "Hide features" : "Browse features"}
+            <span
+              aria-hidden="true"
+              className={`text-xs transition-transform ${
+                navOpen ? "rotate-180" : ""
+              }`}
+            >
+              ▼
+            </span>
+          </button>
+          <nav
+            id="feature-nav"
+            className={`mt-3 lg:mt-0 lg:block ${navOpen ? "block" : "hidden"}`}
+          >
+            <FeatureNav
+              activeFeaturePath={activeFeaturePath}
+              onNavigate={() => setNavOpen(false)}
+            />
+          </nav>
+        </div>
 
-        <main className="bg-slate-800/30 rounded-2xl p-8 border border-slate-700/50 min-h-[400px]">
+        <main className="min-w-0 bg-slate-800/30 rounded-2xl p-4 sm:p-6 lg:p-8 border border-slate-700/50 min-h-[400px]">
           {children}
         </main>
       </div>

--- a/example/routes/features/middleware/basic-auth.tsx
+++ b/example/routes/features/middleware/basic-auth.tsx
@@ -45,7 +45,7 @@ export default function BasicAuthMiddlewareExample({
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           basic-auth.ts
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
 

--- a/example/routes/features/middleware/client-middleware.tsx
+++ b/example/routes/features/middleware/client-middleware.tsx
@@ -183,7 +183,7 @@ export default function ClientMiddlewareExample({
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           Example Code
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`import { createContext } from "react-router";
 import type { MiddlewareFunction } from "@udibo/juniper";
 

--- a/example/routes/features/middleware/client-redirect.tsx
+++ b/example/routes/features/middleware/client-redirect.tsx
@@ -100,7 +100,7 @@ export default function ClientRedirectExample({}: RouteProps) {
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           Example Code
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
           {`import { redirect } from "react-router";
 import type { MiddlewareFunction } from "@udibo/juniper";
 

--- a/example/routes/features/middleware/context-sharing.tsx
+++ b/example/routes/features/middleware/context-sharing.tsx
@@ -91,7 +91,7 @@ export default function ContextSharingExample({
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           context-sharing.tsx (context definition)
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`import { createContext } from "react-router";
 
 export interface RequestInfo {
@@ -109,7 +109,7 @@ export const requestInfoContext =
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           context-sharing.ts (middleware + loader)
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`import { Hono } from "hono";
 import type { AppEnv } from "@udibo/juniper/server";
 import {

--- a/example/routes/features/middleware/logging.tsx
+++ b/example/routes/features/middleware/logging.tsx
@@ -24,7 +24,7 @@ export default function LoggingMiddlewareExample() {
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           Server Output (on page refresh)
         </h4>
-        <pre className="text-sm text-slate-400 font-mono">
+        <pre className="text-sm text-slate-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`<-- GET /features/middleware/logging
 --> GET /features/middleware/logging 200 16ms`}
         </pre>
@@ -34,7 +34,7 @@ export default function LoggingMiddlewareExample() {
         <h4 className="text-sm font-semibold text-slate-300 mb-2">
           logging.ts
         </h4>
-        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto">
+        <pre className="text-sm text-emerald-400 font-mono overflow-x-auto whitespace-pre-wrap wrap-break-word">
 {`import { Hono } from "hono";
 import { logger } from "hono/logger";
 

--- a/example/routes/index.tsx
+++ b/example/routes/index.tsx
@@ -5,8 +5,8 @@ export default function HomePage() {
     <div>
       <title>Juniper - Modern Web Framework for Deno</title>
 
-      <section className="text-center py-16">
-        <h1 className="text-5xl font-bold mb-6 bg-linear-to-r from-emerald-400 to-cyan-400 bg-clip-text text-transparent">
+      <section className="text-center py-12 sm:py-16">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 bg-linear-to-r from-emerald-400 to-cyan-400 bg-clip-text text-transparent">
           Welcome to Juniper
         </h1>
         <p className="text-xl text-slate-300 max-w-2xl mx-auto mb-12 leading-relaxed">
@@ -39,11 +39,11 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="py-16">
-        <h2 className="text-3xl font-bold text-center mb-12 text-slate-100">
+      <section className="py-12 sm:py-16">
+        <h2 className="text-2xl sm:text-3xl font-bold text-center mb-8 sm:mb-12 text-slate-100">
           Why Juniper?
         </h2>
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="grid md:grid-cols-3 gap-6 md:gap-8">
           <div className="bg-slate-800/50 p-8 rounded-2xl border border-slate-700/50 hover:border-emerald-500/30 transition-colors">
             <div className="w-12 h-12 bg-emerald-500/10 rounded-xl flex items-center justify-center mb-4">
               <svg

--- a/example/routes/main.tsx
+++ b/example/routes/main.tsx
@@ -14,7 +14,7 @@ function Shell({ children }: { children: ReactNode }) {
       <link rel="stylesheet" href="/build/main.css" precedence="default" />
       <div className="min-h-screen bg-linear-to-br from-slate-900 via-slate-800 to-slate-900 text-slate-100">
         <nav className="border-b border-slate-700/50 bg-slate-900/80 backdrop-blur-sm sticky top-0 z-50">
-          <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-4">
             <div className="flex items-center justify-between">
               <Link
                 to="/"
@@ -22,7 +22,7 @@ function Shell({ children }: { children: ReactNode }) {
               >
                 Juniper
               </Link>
-              <div className="flex gap-8">
+              <div className="flex gap-6 sm:gap-8">
                 <Link
                   to="/features"
                   className="text-slate-300 hover:text-emerald-400 transition-colors font-medium"
@@ -39,7 +39,7 @@ function Shell({ children }: { children: ReactNode }) {
             </div>
           </div>
         </nav>
-        <main className="max-w-6xl mx-auto px-6 py-12">
+        <main className="max-w-6xl mx-auto px-4 sm:px-6 py-12">
           {children}
         </main>
       </div>
@@ -63,7 +63,7 @@ export function ErrorBoundary(
     <Shell>
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="text-center p-8 max-w-md">
-          <h1 className="text-4xl font-bold text-red-400 mb-4">
+          <h1 className="text-3xl sm:text-4xl font-bold text-red-400 mb-4">
             Something went wrong
           </h1>
           <p className="text-slate-300 mb-6">


### PR DESCRIPTION
## Summary

Closes #45. The example was hard to use on mobile: on the features demo the left sidebar nav filled the entire viewport and pushed the example content below the fold, and wide code blocks caused horizontal page scrolling ("scroll right shows white space"). This makes the example look good on both mobile and desktop.

## Changes

- **Features layout** (`routes/features/main.tsx`): collapse the feature nav behind a full-width "Browse features" toggle on mobile so the example content is visible immediately; keep the persistent 280px sidebar at `lg+`. Renders the nav once (no duplicate links), is accessible via `aria-expanded`/`aria-controls`, and auto-collapses on selection. Fixed the underlying horizontal overflow — a single `auto` grid column stretched by a wide `<pre>` — with `grid-cols-1` + `min-w-0`.
- **Code blocks**: `CodeBlock` and the raw `<pre>` blocks now wrap long lines (`whitespace-pre-wrap wrap-break-word`) instead of forcing sideways scroll.
- **Type scale**: responsive sizing for the hero heading, blog post titles, error headings, and the fetcher counter.
- **Spacing**: responsive container padding (`px-4 sm:px-6`) and tighter gaps/section padding on mobile.
- **Blog**: header, pagination, and create/edit button rows stack vertically (full-width buttons) on mobile.

## Testing

- All 33 example test files pass (329 steps); added two tests for the nav toggle and updated one assertion for the reworded features-index copy.
- `deno check`, `deno lint`, and `deno fmt --check` all pass.
- Manually verified in-browser at 375px (mobile) and 1280px (desktop) across home, features, a code-heavy feature page, blog index, and the create form — no horizontal overflow at 375px, desktop layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
