### PR TITLE
ci: pin @sebbo2002/semantic-release-jsr to 3.2.1

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # @sebbo2002/semantic-release-jsr@4.0.0 ships a CJS bundle that
+        # semantic-release rejects as an invalid plugin config (EPLUGINSCONF):
+        # https://github.com/sebbo2002/semantic-release-jsr/issues/153
+        # Fixed upstream on @next (4.0.1-develop); pin to the last good 3.x and
+        # un-pin to ^4.0.1 once it ships stable. The other tools track latest.
         run: >-
           npx
           --package semantic-release
@@ -149,5 +154,5 @@ jobs:
           --package @semantic-release/exec
           --package @semantic-release/git
           --package @semantic-release/github
-          --package @sebbo2002/semantic-release-jsr
+          --package @sebbo2002/semantic-release-jsr@3.2.1
           semantic-release


### PR DESCRIPTION
## Problem

The **Release** job has failed on every push to `main` since [run 27482917285](https://github.com/udibo/juniper/actions/runs/27482917285/job/81233865760):

```
✘  EPLUGINSCONF The `plugins` configuration is invalid.
The invalid configuration is Object [Module] { fail, …, verifyConditions }
```

## Root cause

The `npx` command pins no versions, so each `--package` floats to its latest. `@sebbo2002/semantic-release-jsr` published **4.0.0** the day after our last release, and its new CJS bundle tags `module.exports` with `Symbol.toStringTag = "Module"`. semantic-release loads a plugin by importing that CJS entry and requires the result to be a plain object (`lodash.isPlainObject`) — a `Module`-tagged object fails the check, so the whole config is rejected.

This is purely the plugin's build output (not a config error): with `semantic-release` held constant, jsr `3.2.1` loads fine and only jsr `4.0.0` reproduces the error.

Tracked upstream in [sebbo2002/semantic-release-jsr#153](https://github.com/sebbo2002/semantic-release-jsr/issues/153), **already fixed on `@next`** (`4.0.1-develop`) — but not yet in a stable release, so floating `latest` is still the broken `4.0.0`.

## Fix

Pin **only** `@sebbo2002/semantic-release-jsr` to `3.2.1` (the last working release). The other five tools keep tracking latest. `4.0.0` shipped no features (it only dropped Node 20 support), so nothing is lost by staying on 3.x.

**Follow-up:** un-pin to `^4.0.1` once it's released stable.

Verified locally with `semantic-release --dry-run --no-ci`: every plugin loads on `3.2.1`; swapping only jsr to `4.0.0` reproduces `EPLUGINSCONF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)