### PR TITLE
chore: remove git:rebase task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -171,10 +171,6 @@
       "description": "Checks the code for errors, formatting, and runs the linter.",
       "command": "deno check && deno lint && deno fmt --check"
     },
-    "git:rebase": {
-      "description": "Gets your branch up to date with master after a squash merge.",
-      "command": "git fetch origin main && git rebase --onto origin/main HEAD"
-    },
     "lgtm:start": {
       "description": "Starts the LGTM service.",
       "command": "docker compose up -d --wait lgtm"


### PR DESCRIPTION
## Summary

Removes the `git:rebase` task as part of moving to a branch-from-`main` workflow (no long-lived `dev` branch kept in sync via rebase). Branch off `main` when ready to commit, stay on the branch until it squash-merges, then return to `main`.

## Changes

- **`deno.json`**: remove the `git:rebase` task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)