### PR TITLE
feat: support react-router 8

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -53,7 +53,7 @@
     "npm:quick-lru@^7.3.0": "7.3.0",
     "npm:react-dom@^19.2.7": "19.2.7_react@19.2.7",
     "npm:react-error-boundary@^6.1.2": "6.1.2_react@19.2.7",
-    "npm:react-router@^7.16.0": "7.17.0_react@19.2.7_react-dom@19.2.7__react@19.2.7",
+    "npm:react-router@^8.3.0": "8.3.0_react@19.2.7_react-dom@19.2.7__react@19.2.7",
     "npm:react@^19.2.7": "19.2.7",
     "npm:sass@^1.93.3": "1.100.0",
     "npm:stylus@0.64": "0.64.0",
@@ -1246,14 +1246,14 @@
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
+    "cookie-es@3.1.1": {
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
+    },
     "cookie-signature@1.2.2": {
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
     },
     "cookie@0.7.2": {
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-    },
-    "cookie@1.1.1": {
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
     },
     "copy-anything@3.0.5": {
       "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
@@ -1523,7 +1523,7 @@
         "body-parser",
         "content-disposition",
         "content-type@1.0.5",
-        "cookie@0.7.2",
+        "cookie",
         "cookie-signature",
         "debug",
         "depd",
@@ -2239,13 +2239,12 @@
     "react-is@17.0.2": {
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-router@7.17.0_react@19.2.7_react-dom@19.2.7__react@19.2.7": {
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+    "react-router@8.3.0_react@19.2.7_react-dom@19.2.7__react@19.2.7": {
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "dependencies": [
-        "cookie@1.1.1",
+        "cookie-es",
         "react",
-        "react-dom",
-        "set-cookie-parser"
+        "react-dom"
       ],
       "optionalPeers": [
         "react-dom"
@@ -2332,9 +2331,6 @@
         "parseurl",
         "send"
       ]
-    },
-    "set-cookie-parser@2.7.2": {
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "setprototypeof@1.2.0": {
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
@@ -2622,7 +2618,7 @@
           "npm:hono@^4.12.23",
           "npm:playwright@^1.60.0",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7",
           "npm:tailwindcss@^4.3.0",
           "npm:zod@^4.4.3"
@@ -2654,7 +2650,7 @@
           "npm:quick-lru@^7.3.0",
           "npm:react-dom@^19.2.7",
           "npm:react-error-boundary@^6.1.2",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7"
         ]
       },
@@ -2670,7 +2666,7 @@
           "npm:@types/react@^19.2.16",
           "npm:hono@^4.12.23",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7"
         ]
       },
@@ -2690,7 +2686,7 @@
           "npm:hono@^4.12.23",
           "npm:pg@^8.21.0",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7",
           "npm:zod@^4.4.3"
         ]
@@ -2709,7 +2705,7 @@
           "npm:@types/react@^19.2.16",
           "npm:hono@^4.12.23",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7",
           "npm:tailwindcss@^4.3.0"
         ]
@@ -2729,7 +2725,7 @@
           "npm:@types/react@^19.2.16",
           "npm:hono@^4.12.23",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7"
         ]
       },
@@ -2745,7 +2741,7 @@
           "npm:@types/react@^19.2.16",
           "npm:hono@^4.12.23",
           "npm:react-dom@^19.2.7",
-          "npm:react-router@^7.16.0",
+          "npm:react-router@^8.3.0",
           "npm:react@^19.2.7"
         ]
       }

--- a/example/deno.json
+++ b/example/deno.json
@@ -48,7 +48,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "tailwindcss": "npm:tailwindcss@^4.3.0",
     "@tailwindcss/postcss": "npm:@tailwindcss/postcss@^4.3.0",

--- a/src/_client.tsx
+++ b/src/_client.tsx
@@ -16,7 +16,6 @@ import type {
   LoaderFunction,
   LoaderFunctionArgs,
   MiddlewareFunction as ReactRouterMiddlewareFunction,
-  RouterContextProvider,
 } from "react-router";
 import React, { createContext, Suspense, useContext } from "react";
 import type { ComponentType } from "react";
@@ -35,11 +34,12 @@ import type {
   ErrorBoundaryProps,
   HydrateFallbackProps,
   MiddlewareFunction,
+  RequestContext,
   RouteModule,
   RouteProps,
 } from "./mod.ts";
 
-const JuniperContext = createContext<RouterContextProvider | undefined>(
+const JuniperContext = createContext<RequestContext | undefined>(
   undefined,
 );
 
@@ -47,7 +47,7 @@ export function JuniperContextProvider({
   context,
   children,
 }: {
-  context: RouterContextProvider;
+  context: RequestContext;
   children: React.ReactNode;
 }) {
   return (
@@ -57,7 +57,7 @@ export function JuniperContextProvider({
   );
 }
 
-export function useJuniperContext(): RouterContextProvider {
+export function useJuniperContext(): RequestContext {
   const context = useContext(JuniperContext);
   if (!context) {
     throw new Error(
@@ -329,12 +329,12 @@ export type Route = {
   ErrorBoundary?: ComponentType;
   HydrateFallback?: ComponentType;
   loader?: (
-    args: LoaderFunctionArgs<RouterContextProvider>,
+    args: LoaderFunctionArgs<RequestContext>,
   ) => unknown | Promise<unknown>;
   action?: (
-    args: ActionFunctionArgs<RouterContextProvider>,
+    args: ActionFunctionArgs<RequestContext>,
   ) => unknown | Promise<unknown>;
-  middleware?: ReactRouterMiddlewareFunction<RouterContextProvider>[];
+  middleware?: ReactRouterMiddlewareFunction<RequestContext>[];
 };
 
 export type LazyRouteResult = Omit<Route, "middleware">;
@@ -407,9 +407,9 @@ export function createRoute(
     };
   }
 
-  let loader: LoaderFunction<RouterContextProvider> | undefined;
+  let loader: LoaderFunction<RequestContext> | undefined;
   if (_loader) {
-    loader = function loader(args: LoaderFunctionArgs<RouterContextProvider>) {
+    loader = function loader(args: LoaderFunctionArgs<RequestContext>) {
       const { context, params } = args;
       const request = withCachedRequest(args.request);
       const serverLoader = () => getServerLoader(request);
@@ -420,7 +420,7 @@ export function createRoute(
       return result;
     };
   } else if (hasServerLoader) {
-    loader = function loader(args: LoaderFunctionArgs<RouterContextProvider>) {
+    loader = function loader(args: LoaderFunctionArgs<RequestContext>) {
       if (HydrateFallback) {
         return { promise: getServerLoader(args.request) };
       }
@@ -429,18 +429,18 @@ export function createRoute(
   }
 
   let action:
-    | ActionFunction<RouterContextProvider>
+    | ActionFunction<RequestContext>
     | undefined;
 
   if (_action) {
-    action = function action(args: ActionFunctionArgs<RouterContextProvider>) {
+    action = function action(args: ActionFunctionArgs<RequestContext>) {
       const { context, params } = args;
       const request = withCachedRequest(args.request);
       const serverAction = () => getServerAction(request);
       return _action({ context, params, request, serverAction });
     };
   } else if (hasServerAction) {
-    action = function action(args: ActionFunctionArgs<RouterContextProvider>) {
+    action = function action(args: ActionFunctionArgs<RequestContext>) {
       const request = withCachedRequest(args.request);
       return getServerAction(request);
     };
@@ -532,19 +532,17 @@ export function createRoute(
   }
 
   let middleware:
-    | ReactRouterMiddlewareFunction<RouterContextProvider>[]
+    | ReactRouterMiddlewareFunction<RequestContext>[]
     | undefined;
   if (_middleware && _middleware.length > 0) {
     middleware = _middleware.map((mw: MiddlewareFunction) => {
-      const wrappedMiddleware: ReactRouterMiddlewareFunction<
-        RouterContextProvider
-      > = (
+      const wrappedMiddleware: ReactRouterMiddlewareFunction<RequestContext> = (
         args,
         next,
       ) => {
         return mw(
           {
-            context: args.context as RouterContextProvider,
+            context: args.context,
             params: args.params,
             request: args.request,
           },

--- a/src/deno.json
+++ b/src/deno.json
@@ -48,7 +48,7 @@
     "@types/react": "npm:@types/react@^19.2.16",
     "react-dom": "npm:react-dom@^19.2.7",
     "react-error-boundary": "npm:react-error-boundary@^6.1.2",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
     "global-jsdom": "npm:global-jsdom@^29.0.0"
   },

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,6 +16,17 @@ import {
 export { HttpError, RouterContextProvider };
 
 /**
+ * The request-scoped context as route handlers and components receive it.
+ *
+ * Read `context.get(someContext)` and write `context.set(someContext, value)`
+ * through it exactly as before — the read-only wrapper only prevents replacing
+ * the provider itself, which React Router owns for the lifetime of a request.
+ * Reach for this over {@linkcode RouterContextProvider} whenever the value came
+ * from a loader, action, middleware, or component prop.
+ */
+export type RequestContext = Readonly<RouterContextProvider>;
+
+/**
  * React Router's redirect helpers, re-exported so routes can choose the
  * redirect kind from one import: {@linkcode redirect} for a client-side (SPA)
  * transition, {@linkcode redirectDocument} for a full-page navigation (the
@@ -349,7 +360,7 @@ export interface RouteLoaderArgs<
   LoaderData = unknown,
 > {
   /** The request-scoped router context, shared across middleware, loaders, and actions. */
-  context: RouterContextProvider;
+  context: RequestContext;
   /** The matched route params. */
   params: Params;
   /** The incoming request. */
@@ -414,7 +425,7 @@ export interface RouteActionArgs<
   ActionData = unknown,
 > {
   /** The request-scoped router context, shared across middleware, loaders, and actions. */
-  context: RouterContextProvider;
+  context: RequestContext;
   /** The matched route params. */
   params: Params;
   /** The incoming request. */
@@ -449,7 +460,7 @@ export interface RouteMiddlewareArgs<
   Params extends AnyParams = AnyParams,
 > {
   /** The request-scoped router context, shared across middleware, loaders, and actions. */
-  context: RouterContextProvider;
+  context: RequestContext;
   /** The matched route params. */
   params: Params;
   /** The incoming request. */
@@ -500,7 +511,7 @@ export type MiddlewareFunction<
   Params extends AnyParams = AnyParams,
 > = (
   args: RouteMiddlewareArgs<Params>,
-  next: () => Promise<RouterContextProvider>,
+  next: () => Promise<RequestContext>,
 ) => Promise<void> | void;
 
 /**
@@ -600,7 +611,7 @@ export interface RouteProps<
   /** The action data of the route. */
   actionData: ActionData;
   /** The router context shared by middleware, loaders, actions, and components. */
-  context: RouterContextProvider;
+  context: RequestContext;
 }
 
 /**
@@ -688,7 +699,7 @@ export interface HydrateFallbackProps<
   /** The params of the route. */
   params: Params;
   /** The router context shared by middleware, loaders, actions, and components. */
-  context: RouterContextProvider;
+  context: RequestContext;
 }
 
 /**

--- a/templates/minimal/deno.json
+++ b/templates/minimal/deno.json
@@ -40,7 +40,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },

--- a/templates/postgres/deno.json
+++ b/templates/postgres/deno.json
@@ -93,7 +93,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },

--- a/templates/tailwindcss/deno.json
+++ b/templates/tailwindcss/deno.json
@@ -42,7 +42,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "tailwindcss": "npm:tailwindcss@^4.3.0",
     "@tailwindcss/postcss": "npm:@tailwindcss/postcss@^4.3.0",

--- a/templates/tanstack/deno.json
+++ b/templates/tanstack/deno.json
@@ -42,7 +42,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
     "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1"

--- a/tutorials/blog/deno.json
+++ b/tutorials/blog/deno.json
@@ -41,7 +41,7 @@
     "react": "npm:react@^19.2.7",
     "react-dom": "npm:react-dom@^19.2.7",
     "@types/react": "npm:@types/react@^19.2.16",
-    "react-router": "npm:react-router@^7.16.0",
+    "react-router": "npm:react-router@^8.3.0",
     "hono": "npm:hono@^4.12.23",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2"
   },


### PR DESCRIPTION
## Summary

Adds react-router 8 support. React Router 8 changed two things juniper's types depend on: route handlers now receive a **read-only** view of the request context, and the lazy-route type was renamed to `LazyRouteDefinition`. Both surfaced as type errors the moment the dependency moved.

This also clears two `high` advisories that currently block CI on the main udibo app, which consumes `@udibo/juniper` from JSR: CVE-2026-55685 (unauthenticated DoS via inefficient route matching, fixed in 7.18.0) and GHSA-qwww-vcr4-c8h2 (RSC-mode CSRF bypass, fixed in 8.3.0). The second has no CVE id, so `deno audit --ignore` cannot exclude it — upgrading is the only way past it.

Released as a **minor** (`feat:`), not a major: the runtime behaviour of every juniper API is unchanged.

## Changes

- Add `RequestContext` (`Readonly<RouterContextProvider>`) and use it for every context that originates from react-router — loader/action/middleware args, route component and error-boundary props, `HydrateFallbackProps`, and `useJuniperContext()`.
- Drop the `args.context as RouterContextProvider` cast in the client middleware wrapper; it existed only to paper over the old mismatch and is now unnecessary.
- Bump `react-router` to `^8.3.0` in `src`, the example, all four templates, and the blog tutorial.

## Upgrade note for consumers

`context.get(...)` and `context.set(...)` work exactly as before — the read-only wrapper only prevents replacing the provider itself, which React Router owns for the request's lifetime. `RouterContextProvider` is still exported unchanged for code that constructs one.

The one visible change: annotations written as `const ctx: RouterContextProvider = useJuniperContext()` no longer type-check, because `Readonly<T>` does not carry the class's private brand. Use `RequestContext` (or let it infer). Nothing needs to change at a call site that just uses the value.

## Testing

`deno task check` clean (226 + 278 files) and the full suite green — 19 passed, 266 steps, 0 failed — against react-router 8.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
