### PR TITLE
fix(testing): define ResizeObserver in global-jsdom

### DIFF
--- a/src/utils/global-jsdom.test.ts
+++ b/src/utils/global-jsdom.test.ts
@@ -1,0 +1,30 @@
+import "./global-jsdom.ts";
+
+import { assert, assertEquals, assertInstanceOf } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+describe("global-jsdom", () => {
+  it("defines ResizeObserver, which JSDOM omits", () => {
+    assert(
+      "ResizeObserver" in globalThis,
+      "libraries that measure elements construct one during ordinary interaction",
+    );
+
+    const observer = new ResizeObserver(() => {});
+    assertInstanceOf(observer.observe, Function);
+    assertInstanceOf(observer.unobserve, Function);
+    assertInstanceOf(observer.disconnect, Function);
+  });
+
+  it("leaves observing an element inert rather than reporting a resize", () => {
+    let reported = false;
+    const observer = new ResizeObserver(() => {
+      reported = true;
+    });
+
+    observer.observe(globalThis.document.body);
+    observer.disconnect();
+
+    assertEquals(reported, false);
+  });
+});

--- a/src/utils/global-jsdom.ts
+++ b/src/utils/global-jsdom.ts
@@ -7,6 +7,12 @@
  * This module automatically:
  * - Registers JSDOM globals (document, window, etc.) with the correct localhost URL
  * - Stubs FormData to work with JSDOM form elements
+ * - Stubs `ResizeObserver`, which JSDOM does not implement, so that libraries
+ *   which measure elements (Headless UI, Floating UI, TanStack Virtual) can run
+ *   under test instead of throwing a `ReferenceError` from an event handler
+ *
+ * The `ResizeObserver` stub never reports a resize. A test that asserts on
+ * measured layout should drive the measurement itself rather than expect one.
  *
  * The only reason to use `npm:global-jsdom` directly instead is if you need a URL
  * other than localhost. If you do that, you should also call `stubFormData` from
@@ -32,6 +38,16 @@ globalJsdom(undefined, {
   url: `http://localhost:${port}`,
   pretendToBeVisual: true,
 });
+
+class NoopResizeObserver implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!("ResizeObserver" in globalThis)) {
+  globalThis.ResizeObserver = NoopResizeObserver;
+}
 
 // Stubbed globally and never restored.
 stubFormData();


### PR DESCRIPTION
## Problem

JSDOM does not implement `ResizeObserver`. Any library that measures an element constructs one during ordinary interaction — Headless UI, Floating UI, TanStack Virtual all do.

Concretely: **closing a Headless UI menu** calls `detectMovement`, which does `new ResizeObserver(...)`. Under `@udibo/juniper/utils/global-jsdom` that throws:

```
error: ReferenceError: ResizeObserver is not defined
    at p (@headlessui/react/dist/utils/element-movement.js:1:332)
    at @headlessui/react/dist/components/menu/menu-machine.js:1:5597
    ...
    at onKeyDown (@headlessui/react/dist/utils/render.js:4:1524)
```

Because the throw escapes a React event dispatch rather than an assertion, Deno does not attribute it to the test — it reports an uncaught error and fails the entire module:

> This error was not caught from a test and caused the test runner to fail on the referenced module.

So a Juniper app cannot write a test that closes a menu at all. Downstream this is currently worked around by hand-rolling a no-op `ResizeObserver` in individual test files, which is exactly the kind of environment setup `global-jsdom` exists to own.

## Change

Stub `ResizeObserver` alongside the existing `FormData` stub, guarded so a real implementation (or a test's own stub) still wins.

The stub never reports a resize — a test that asserts on measured layout should drive the measurement itself. That is documented in the module JSDoc.

## Verification

`deno task test src/utils/global-jsdom.test.ts` — new test covers that the global is defined, constructible, has the full observer surface, and stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)