### PR TITLE
feat(server): apply the request's CSP nonce to every inline script

### DIFF
--- a/src/_server.tsx
+++ b/src/_server.tsx
@@ -125,6 +125,17 @@ export function getRouteContext(): RouteContext | undefined {
 export type AppEnv = Env & {
   Variables: {
     context: RouterContextProvider;
+    /**
+     * A per-request CSP nonce, if the app generates one. Hono's `secureHeaders`
+     * sets this variable when its `contentSecurityPolicy` names `NONCE`, and
+     * Juniper applies it to every inline script it emits — its own hydration
+     * script, and the ones React's streaming renderer injects to resolve
+     * Suspense boundaries.
+     *
+     * Absent when the app does not use nonces, in which case nothing changes:
+     * the attribute is simply omitted.
+     */
+    secureHeadersNonce?: string;
   };
 };
 
@@ -207,12 +218,16 @@ export interface Route<
 }
 
 function HydrationScript(
-  { serializedHydrationData }: { serializedHydrationData: Promise<string> },
+  { serializedHydrationData, nonce }: {
+    serializedHydrationData: Promise<string>;
+    nonce?: string;
+  },
 ) {
   const hydrateScript = use(serializedHydrationData);
   return (
     <script
       type="module"
+      nonce={nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{ __html: hydrateScript }}
     />
@@ -298,6 +313,12 @@ async function renderDocument(
 
   const router = createStaticRouter(dataRoutes, context);
 
+  // Set by Hono's `secureHeaders` when the app's CSP names NONCE. Read here
+  // rather than generated, because the header carrying it is written by
+  // middleware that has already run — a nonce minted at render time would
+  // never match the policy the browser was given.
+  const nonce = c.get("secureHeadersNonce");
+
   let renderStream: Awaited<ReturnType<typeof renderToReadableStream>>;
   let aborted = false;
   let renderAttempts = 0;
@@ -346,11 +367,18 @@ async function renderDocument(
               <Suspense fallback={null}>
                 <HydrationScript
                   serializedHydrationData={serializedHydrationData}
+                  nonce={nonce}
                 />
               </Suspense>
             </App>
           </StrictMode>,
           {
+            // Covers what this file cannot reach: the scripts React injects
+            // itself to resolve Suspense boundaries, whose bodies differ per
+            // response and so can never be hashed. Without it a nonce on the
+            // hydration script alone would still leave `unsafe-inline`
+            // load-bearing.
+            nonce,
             bootstrapModules: ["/build/main.js"],
             bootstrapScripts,
             signal: request.signal,

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -9,6 +9,7 @@ import {
 import type { LoaderFunctionArgs } from "react-router";
 
 import { Hono } from "hono";
+import { NONCE, secureHeaders } from "hono/secure-headers";
 
 import type { RouteLoaderArgs } from "./mod.ts";
 import { HttpError } from "./mod.ts";
@@ -71,6 +72,73 @@ describe("createServer", () => {
     const contactText = await contactRes.text();
     assertStringIncludes(contactText, "<!DOCTYPE html>");
     assertStringIncludes(contactText, "<div>Contact</div>");
+  });
+
+  it("puts the request's CSP nonce on every inline script it emits", async () => {
+    const client = new Client({
+      path: "/",
+      main: { default: () => <div>Nonced</div> },
+    });
+    const server = createServer(import.meta.url, client, { path: "/" });
+
+    // Wired the way an app does it: `secureHeaders` generates the nonce, writes
+    // it into the policy it sends, and exposes it for the renderer. Testing
+    // against the real middleware is the point — a hand-set variable would pass
+    // whatever name this happened to read.
+    const app = new Hono();
+    app.use(secureHeaders({
+      contentSecurityPolicy: { scriptSrc: ["'self'", NONCE] },
+    }));
+    app.route("/", server);
+
+    const response = await app.request("http://localhost/");
+    const text = await response.text();
+
+    const policy = response.headers.get("content-security-policy") ?? "";
+    const nonce = policy.match(/'nonce-([^']+)'/)?.[1];
+    assertExists(nonce, "the policy carries a nonce to match against");
+
+    // Match the hydration script *specifically*. Asserting the nonce appears
+    // anywhere passes on React's bootstrap tag alone, which carries it from the
+    // renderToReadableStream option — so the check would survive the attribute
+    // being dropped from the script this file actually renders.
+    const hydrationTag = text.match(
+      /<script[^>]*>(?=[^<]*__juniperHydrationData)/,
+    );
+    assertExists(hydrationTag, "the hydration script is in the document");
+    assertStringIncludes(hydrationTag[0], `nonce="${nonce}"`);
+
+    const bootstrapTag = text.match(
+      /<script[^>]*src="\/build\/main\.js"[^>]*>/,
+    );
+    assertExists(bootstrapTag, "React's bootstrap script is in the document");
+    assertStringIncludes(
+      bootstrapTag[0],
+      `nonce="${nonce}"`,
+      "the renderToReadableStream option covers what this file cannot reach",
+    );
+    assertEquals(
+      text.includes("unsafe-inline"),
+      false,
+      "nothing falls back to the directive this replaces",
+    );
+  });
+
+  it("omits the nonce attribute when the app sets none", async () => {
+    const client = new Client({
+      path: "/",
+      main: { default: () => <div>Plain</div> },
+    });
+    const server = createServer(import.meta.url, client, { path: "/" });
+
+    const text = await (await server.request("http://localhost/")).text();
+
+    assertEquals(
+      text.includes("nonce="),
+      false,
+      "an app without a CSP nonce keeps exactly the markup it had before",
+    );
+    assertStringIncludes(text, "__juniperHydrationData");
   });
 
   it("should give priority to server routes over client routes", async () => {


### PR DESCRIPTION
Enables udibo/udibo#542 — an app cannot drop `'unsafe-inline'` from `script-src` while Juniper renders inline scripts it has no way to nonce.

## There are two inline scripts, and only a nonce covers both

- **The hydration script** this file writes. Its body carries per-request loader data, so it can never be hashed.
- **React's own streaming scripts**, injected to resolve Suspense boundaries. `HydrationScript` is itself rendered inside `<Suspense>`, so these always exist — and their bodies differ per response by construction.

That second one is why a nonce is the answer rather than a data block. Moving the hydration payload into `<script type="application/json">` would remove *Juniper's* executable script but leave React's, and `'unsafe-inline'` would still be load-bearing. `renderToReadableStream` takes a `nonce` option precisely because this is unavoidable.

## The nonce is read, not generated

`c.get("secureHeadersNonce")`. Hono's `secureHeaders` mints it while writing the policy that carries it, and that middleware has already run by render time — a nonce minted here would never match the header the browser was given.

Apps that set no nonce are unchanged: the attribute is omitted and `renderToReadableStream` receives `undefined`.

## About the test

It wires Hono's **real** `secureHeaders` rather than setting the context variable by hand. That is deliberate — a hand-set variable would pass against whatever name this code happened to read, proving only that I'm consistent with myself. Wiring the real middleware is what establishes that `secureHeadersNonce` is the name apps will actually produce.

It also matches **each script tag individually**, which mattered more than expected: the first version asserted the nonce appeared *anywhere* in the document, and that passed on React's bootstrap tag alone — it survived the attribute being dropped from the hydration script entirely. Mutation testing caught it. Both placements are now separately load-bearing; removing either turns the test red.

`deno task check` and `deno task test` green (20 passed, 275 steps).

## What still has to happen app-side

This unblocks the CSP change; it does not make it. The consuming app still needs to put `NONCE` in its `script-src`, drop `'unsafe-inline'`, and nonce any inline script of its own (udibo has a theme bootstrap in `routes/main.tsx`). Those land separately against #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
