### PR TITLE
fix: recover from deploy skew instead of dying on it

### DIFF
--- a/src/_client.tsx
+++ b/src/_client.tsx
@@ -229,6 +229,63 @@ function clearReloadState(key: string): void {
 
 const LAZY_LOAD_RELOAD_KEY = "__juniper_lazy_load_reload";
 const SAME_LOCATION_RELOAD_KEY = "__juniper_same_location_reload";
+const BUILD_SKEW_RELOAD_KEY = "__juniper_build_skew_reload";
+
+interface RouterLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+interface NavigationalRouter {
+  state: {
+    location: RouterLocation;
+    navigation: { location?: RouterLocation };
+  };
+}
+
+let activeRouter: NavigationalRouter | undefined;
+
+/**
+ * Registers the hydrated router so failure recovery can hard-navigate to the
+ * navigation's destination instead of reloading whatever URL happens to be
+ * current. Called by `Client.hydrate`; `undefined` clears the registration.
+ */
+export function registerRouter(router: NavigationalRouter | undefined): void {
+  activeRouter = router;
+}
+
+function recoveryDestination(): string {
+  const target = activeRouter?.state.navigation.location ??
+    activeRouter?.state.location;
+  return target
+    ? `${target.pathname}${target.search}${target.hash}`
+    : globalThis.location.href;
+}
+
+/**
+ * Whether an error is a failed dynamic module import — the error a missing
+ * route chunk produces. Matched by message because every browser throws its
+ * own `TypeError` for it, and it matters to recovery: the browser caches the
+ * failed import for the document's lifetime, so only a document navigation
+ * (never a client-side retry) can succeed afterwards.
+ */
+export function isModuleLoadError(error: unknown): boolean {
+  return error instanceof TypeError &&
+    /dynamically imported module|Importing a module script failed/i
+      .test(error.message);
+}
+
+let clientBuildId: string | undefined;
+
+/**
+ * Records the build id the document was rendered with (from hydration data),
+ * compared against the `X-Juniper-Build` header on data responses to detect a
+ * new deployment. Called by `Client.hydrate`; `undefined` disables the check.
+ */
+export function setClientBuildId(buildId: string | undefined): void {
+  clientBuildId = buildId;
+}
 
 // Never settles, so React Router stays pending during a full-page navigation/reload; resolving would render the destination route for a frame and flash the wrong page.
 function holdForDocumentNavigation(): Promise<never> {
@@ -250,6 +307,22 @@ async function fetchServerData(
   }
 
   const response = await fetch(request.url, fetchOptions);
+
+  if (method === "GET") {
+    const serverBuildId = response.headers.get("X-Juniper-Build");
+    if (clientBuildId && serverBuildId) {
+      if (serverBuildId === clientBuildId) {
+        clearReloadState(BUILD_SKEW_RELOAD_KEY);
+      } else if (shouldReload(BUILD_SKEW_RELOAD_KEY)) {
+        recordReload(BUILD_SKEW_RELOAD_KEY);
+        await response.body?.cancel();
+        delay(0).then(() => {
+          globalThis.location.assign(request.url);
+        });
+        return holdForDocumentNavigation();
+      }
+    }
+  }
 
   const contentType = response.headers.get("Content-Type");
 
@@ -514,6 +587,12 @@ export function createRoute(
       }
 
       function resetErrorBoundary() {
+        if (isModuleLoadError(routeError)) {
+          globalThis.location.assign(
+            location.pathname + location.search + location.hash,
+          );
+          return;
+        }
         navigate(location.pathname, { replace: true });
       }
 
@@ -567,6 +646,13 @@ export function createRoute(
  * Creates a lazy route object that loads a `RouteModule` and converts it to a route object.
  * Note: Middleware cannot be lazily loaded per React Router constraints, so it is stripped.
  *
+ * A failed module load (typically a deployment replaced the hashed chunks an
+ * open tab still references) recovers by hard-navigating to the navigation's
+ * destination — the server can always render it, and the fresh document
+ * carries the new build's chunk names. Recovery is loop-guarded via
+ * `sessionStorage`; once the guard trips the error is left to surface in the
+ * nearest ErrorBoundary.
+ *
  * @param lazyRouteFile - The lazy route file to create a lazy route object from.
  * @param serverFlags - Flags indicating whether the route has server-side loader/action.
  * @param routeId - The route ID used for server data requests.
@@ -585,8 +671,9 @@ export function createLazyRoute(
     } catch (error) {
       if (shouldReload(LAZY_LOAD_RELOAD_KEY)) {
         recordReload(LAZY_LOAD_RELOAD_KEY);
+        const destination = recoveryDestination();
         delay(0).then(() => {
-          globalThis.location.reload();
+          globalThis.location.assign(destination);
         });
       }
       throw error;

--- a/src/_serialization.ts
+++ b/src/_serialization.ts
@@ -791,6 +791,12 @@ export interface HydrationData {
   loaderData?: Record<string, unknown>;
   /** Action data for each route */
   actionData?: Record<string, unknown>;
+  /**
+   * Identifier of the build that produced the document, compared against the
+   * `X-Juniper-Build` header on data responses to detect a new deployment.
+   * Absent when the server has no build output to identify.
+   */
+  buildId?: string;
 }
 
 /**
@@ -830,11 +836,13 @@ export function deserializeHydrationData(
     errors?: Record<string, unknown> | null;
     loaderData?: Record<string, unknown> | null;
     actionData?: Record<string, unknown> | null;
+    buildId?: string;
   };
 
   return {
     publicEnv: serialized.publicEnv,
     serializedContext: restored.serializedContext,
+    buildId: restored.buildId,
     matches: restored.matches,
     // React Router needs undefined, not null, for these fields.
     errors: restored.errors ?? undefined,

--- a/src/_server.tsx
+++ b/src/_server.tsx
@@ -136,8 +136,50 @@ export type AppEnv = Env & {
      * the attribute is simply omitted.
      */
     secureHeadersNonce?: string;
+    /**
+     * Identifier of the build serving this request, set by `createServer` when
+     * the project has client build output. Embedded in the hydration data and
+     * echoed as the `X-Juniper-Build` header on data responses so a stale tab
+     * can detect a new deployment before it requests a chunk that no longer
+     * exists.
+     */
+    buildId?: string;
   };
 };
+
+const buildIds = new Map<string, Promise<string | undefined>>();
+
+/**
+ * Identifier of the client build under `projectRoot`: a content hash of
+ * `public/build/main.js`, computed once per root for the life of the process —
+ * a deployment's build output never changes, and deriving it from content
+ * means every instance of one deployment agrees. Resolves `undefined` when
+ * there is no build output to identify, which leaves version-skew detection
+ * inert.
+ */
+export function getBuildId(projectRoot: string): Promise<string | undefined> {
+  let id = buildIds.get(projectRoot);
+  if (!id) {
+    id = (async () => {
+      try {
+        const content = await Deno.readFile(
+          path.resolve(projectRoot, "./public/build/main.js"),
+        );
+        const digest = new Uint8Array(
+          await crypto.subtle.digest("SHA-256", content),
+        );
+        return Array.from(
+          digest.subarray(0, 8),
+          (byte) => byte.toString(16).padStart(2, "0"),
+        ).join("");
+      } catch {
+        return undefined;
+      }
+    })();
+    buildIds.set(projectRoot, id);
+  }
+  return id;
+}
 
 interface ServerRouteModule {
   // deno-lint-ignore no-explicit-any -- Accepts any Hono app regardless of its type parameters
@@ -302,6 +344,7 @@ async function renderDocument(
           errors: context.errors ?? undefined,
           loaderData: context.loaderData ?? undefined,
           actionData: context.actionData ?? undefined,
+          buildId: c.get("buildId"),
         };
 
         const serializedHydrationData = serializeHydrationData(

--- a/src/client.test.tsx
+++ b/src/client.test.tsx
@@ -6,7 +6,13 @@ import {
   assertObjectMatch,
   assertRejects,
 } from "@std/assert";
-import { beforeAll, beforeEach, describe, it } from "@std/testing/bdd";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "@std/testing/bdd";
 import { assertSpyCalls, stub } from "@std/testing/mock";
 import { delay } from "@std/async/delay";
 import { HttpError } from "./mod.ts";
@@ -28,6 +34,9 @@ import {
   createLazyRoute,
   createRoute,
   deserializeHydrationData,
+  isModuleLoadError,
+  registerRouter,
+  setClientBuildId,
 } from "./_client.tsx";
 import { serializeHydrationData } from "./_serialization.ts";
 
@@ -749,6 +758,7 @@ describe("HydrationData serialization and deserialization", () => {
     hydrationData = {
       publicEnv: { APP_ENV: "test", APP_NAME: "TestApp" },
       serializedContext: { testKey: "testValue" },
+      buildId: "0123456789abcdef",
       matches: [{ id: "/" }, { id: "/blog" }, { id: "/blog/index" }],
       errors: {
         "/": new Error("Oops"),
@@ -816,12 +826,17 @@ describe("HydrationData serialization and deserialization", () => {
       [
         "publicEnv",
         "serializedContext",
+        "buildId",
         "matches",
         "errors",
         "loaderData",
         "actionData",
       ],
     );
+  });
+
+  it("buildId is the same", () => {
+    assertEquals(deserializedHydrationData.buildId, "0123456789abcdef");
   });
 
   it("matches are the same", () => {
@@ -901,5 +916,286 @@ describe("HydrationData serialization and deserialization", () => {
 
   it("actionData is the same", async () => {
     await assertRouteDataErrors("Action", deserializedHydrationData.actionData);
+  });
+});
+
+describe("createLazyRoute failure recovery", () => {
+  const LAZY_LOAD_RELOAD_KEY = "__juniper_lazy_load_reload";
+  let assigned: string[];
+  let originalLocation: typeof globalThis.location;
+
+  beforeEach(() => {
+    sessionStorage.removeItem(LAZY_LOAD_RELOAD_KEY);
+    registerRouter(undefined);
+    assigned = [];
+    originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: {
+        href: "http://localhost/current",
+        assign: (url: string) => void assigned.push(url),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    sessionStorage.removeItem(LAZY_LOAD_RELOAD_KEY);
+    registerRouter(undefined);
+  });
+
+  function failingLazyRoute() {
+    return createLazyRoute(
+      () => Promise.reject(new Error("chunk missing")),
+      undefined,
+      "route-1",
+    );
+  }
+
+  it("hard-navigates to the in-flight navigation's destination", async () => {
+    registerRouter({
+      state: {
+        location: { pathname: "/current", search: "", hash: "" },
+        navigation: {
+          location: { pathname: "/destination", search: "?q=1", hash: "#top" },
+        },
+      },
+    });
+
+    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
+    await delay(1);
+
+    assertEquals(assigned, ["/destination?q=1#top"]);
+  });
+
+  it("navigates to the settled location when no navigation is in flight", async () => {
+    registerRouter({
+      state: {
+        location: { pathname: "/current", search: "?tab=2", hash: "" },
+        navigation: {},
+      },
+    });
+
+    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
+    await delay(1);
+
+    assertEquals(assigned, ["/current?tab=2"]);
+  });
+
+  it("falls back to location.href when no router is registered", async () => {
+    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
+    await delay(1);
+
+    assertEquals(assigned, ["http://localhost/current"]);
+  });
+
+  it("stops navigating once the loop guard trips, so the error can surface", async () => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
+      await delay(1);
+    }
+
+    assertEquals(assigned.length, 2);
+  });
+});
+
+describe("build skew detection", () => {
+  const BUILD_SKEW_RELOAD_KEY = "__juniper_build_skew_reload";
+  let assigned: string[];
+  let originalLocation: typeof globalThis.location;
+
+  beforeEach(() => {
+    sessionStorage.removeItem(BUILD_SKEW_RELOAD_KEY);
+    setClientBuildId("build-a");
+    assigned = [];
+    originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: {
+        href: "http://localhost/current",
+        assign: (url: string) => void assigned.push(url),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    sessionStorage.removeItem(BUILD_SKEW_RELOAD_KEY);
+    setClientBuildId(undefined);
+  });
+
+  const routeFile: RouteModule = { default: () => <div>Route</div> };
+
+  function loaderArgs(url: string): LoaderFunctionArgs {
+    return {
+      context: {} as never,
+      params: {},
+      request: new Request(url),
+      url: new URL(url),
+      pattern: "/identity",
+    } as LoaderFunctionArgs;
+  }
+
+  it("turns a loader fetch answered by a newer build into a document navigation", async () => {
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("{}", { headers: { "X-Juniper-Build": "build-b" } }),
+        ),
+    );
+
+    const routeObject = createRoute(routeFile, { loader: true }, "route-1");
+    assertExists(routeObject.loader);
+    const result = routeObject.loader(loaderArgs("http://localhost/identity"));
+
+    const pending = Symbol("pending");
+    const outcome = await Promise.race([
+      Promise.resolve(result).then(() => "settled"),
+      delay(10).then(() => pending),
+    ]);
+    assertEquals(outcome, pending);
+    assertEquals(assigned, ["http://localhost/identity"]);
+  });
+
+  it("accepts a matching build id and clears the loop guard", async () => {
+    sessionStorage.setItem(
+      BUILD_SKEW_RELOAD_KEY,
+      JSON.stringify({ count: 1, timestamp: Date.now() }),
+    );
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("{}", { headers: { "X-Juniper-Build": "build-a" } }),
+        ),
+    );
+
+    const routeObject = createRoute(routeFile, { loader: true }, "route-1");
+    assertExists(routeObject.loader);
+    const result = await routeObject.loader(
+      loaderArgs("http://localhost/identity"),
+    );
+
+    assert(result instanceof Response);
+    assertEquals(assigned, []);
+    assertEquals(sessionStorage.getItem(BUILD_SKEW_RELOAD_KEY), null);
+  });
+
+  it("ignores responses that carry no build id", async () => {
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.resolve(new Response("{}")),
+    );
+
+    const routeObject = createRoute(routeFile, { loader: true }, "route-1");
+    assertExists(routeObject.loader);
+    const result = await routeObject.loader(
+      loaderArgs("http://localhost/identity"),
+    );
+
+    assert(result instanceof Response);
+    assertEquals(assigned, []);
+  });
+
+  it("does not turn an action into a document navigation", async () => {
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("{}", { headers: { "X-Juniper-Build": "build-b" } }),
+        ),
+    );
+
+    const routeObject = createRoute(routeFile, { action: true }, "route-1");
+    assertExists(routeObject.action);
+    const body = new FormData();
+    body.set("title", "Hello");
+    const result = await routeObject.action({
+      context: {} as never,
+      params: {},
+      request: new Request("http://localhost/identity", {
+        method: "POST",
+        body,
+      }),
+      url: new URL("http://localhost/identity"),
+      pattern: "/identity",
+    } as ActionFunctionArgs);
+
+    assert(result instanceof Response);
+    assertEquals(assigned, []);
+  });
+
+  it("stops navigating once the loop guard trips", async () => {
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response("{}", { headers: { "X-Juniper-Build": "build-b" } }),
+        ),
+    );
+    const routeObject = createRoute(routeFile, { loader: true }, "route-1");
+    assertExists(routeObject.loader);
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = routeObject.loader(
+        loaderArgs("http://localhost/identity"),
+      );
+      const pending = Symbol("pending");
+      const outcome = await Promise.race([
+        Promise.resolve(result).then(() => "settled"),
+        delay(10).then(() => pending),
+      ]);
+      assertEquals(outcome, pending);
+    }
+    assertEquals(assigned.length, 2);
+
+    const result = await routeObject.loader(
+      loaderArgs("http://localhost/identity"),
+    );
+    assert(result instanceof Response);
+    assertEquals(assigned.length, 2);
+  });
+});
+
+describe("isModuleLoadError", () => {
+  it("matches each browser's failed dynamic import error", () => {
+    assert(
+      isModuleLoadError(
+        new TypeError(
+          "Failed to fetch dynamically imported module: http://localhost/build/a.js",
+        ),
+      ),
+    );
+    assert(
+      isModuleLoadError(
+        new TypeError("error loading dynamically imported module"),
+      ),
+    );
+    assert(
+      isModuleLoadError(new TypeError("Importing a module script failed.")),
+    );
+  });
+
+  it("does not match other errors", () => {
+    assert(!isModuleLoadError(new TypeError("x is not a function")));
+    assert(
+      !isModuleLoadError(
+        new Error("Failed to fetch dynamically imported module: x"),
+      ),
+    );
+    assert(!isModuleLoadError(new HttpError(404, "Not found")));
+    assert(!isModuleLoadError("Failed to fetch dynamically imported module"));
   });
 });

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -21,6 +21,8 @@ import {
   deserializeHydrationData,
   generateRouteId,
   JuniperContextProvider,
+  registerRouter,
+  setClientBuildId,
 } from "./_client.tsx";
 import type { HydrationData, LazyRoute, ServerFlags } from "./_client.tsx";
 import { deserializeAllContext } from "./_serialization.ts";
@@ -288,12 +290,22 @@ export class Client {
   /**
    * Hydrates the application.
    * This function sets up the browser router and renders the application.
+   *
+   * A route module that fails to load here does not abort hydration: the
+   * failure is logged and the router is still created, so React Router
+   * re-attempts the load and surfaces the error in the nearest ErrorBoundary
+   * rather than leaving a server-rendered page with no interactivity.
    */
   async hydrate() {
-    const { matches, serializedContext, ...hydrationData } = this
+    const { matches, serializedContext, buildId, ...hydrationData } = this
       .getHydrationData();
+    setClientBuildId(buildId);
 
-    await this.loadLazyMatches(matches);
+    try {
+      await this.loadLazyMatches(matches);
+    } catch (error) {
+      console.error("Failed to load a route module during hydration:", error);
+    }
 
     const context = new RouterContextProvider();
     deserializeAllContext(
@@ -305,6 +317,7 @@ export class Client {
       hydrationData,
       getContext: () => context,
     });
+    registerRouter(router);
 
     const htmlProps = this.htmlProps;
     function HydratedApp() {

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -1,5 +1,11 @@
-import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+import * as path from "@std/path";
 import {
   Outlet,
   redirectDocument,
@@ -16,8 +22,9 @@ import { HttpError } from "./mod.ts";
 import { Client } from "./client.tsx";
 import { createServer } from "./server.tsx";
 
-import { mergeServerRoutes } from "./_server.tsx";
-import { cborDecode } from "./_serialization.ts";
+import { getBuildId, mergeServerRoutes } from "./_server.tsx";
+import { cborDecode, deserializeHydrationData } from "./_serialization.ts";
+import type { SerializedHydrationData } from "./_serialization.ts";
 
 describe("createServer", () => {
   it("should return 404 for a non-existent route", async () => {
@@ -1102,6 +1109,111 @@ describe("build artifact cache control", () => {
       await res.body?.cancel();
     } finally {
       await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe("build id (deploy-skew handshake)", () => {
+  async function makeProject(mainJs?: string): Promise<string> {
+    const dir = await Deno.makeTempDir();
+    if (mainJs !== undefined) {
+      await Deno.mkdir(path.join(dir, "public", "build"), { recursive: true });
+      await Deno.writeTextFile(
+        path.join(dir, "public", "build", "main.js"),
+        mainJs,
+      );
+    }
+    return dir;
+  }
+
+  function makeServer(projectDir: string) {
+    const client = new Client({
+      path: "/",
+      main: { default: () => <div>Home</div> },
+    });
+    return createServer(
+      path.toFileUrl(path.join(projectDir, "main.ts")).href,
+      client,
+      {
+        path: "/",
+        main: { loader: () => Promise.resolve({ ok: true }) },
+      },
+    );
+  }
+
+  it("stamps data responses and hydration data with the same build id", async () => {
+    const dir = await makeProject(`console.log("build a");`);
+    try {
+      const server = makeServer(dir);
+
+      const dataRes = await server.request("http://localhost/", {
+        headers: { "X-Juniper-Route-Id": "/" },
+      });
+      assertEquals(dataRes.status, 200);
+      const buildId = dataRes.headers.get("X-Juniper-Build");
+      assertExists(buildId);
+      await dataRes.body?.cancel();
+
+      const docRes = await server.request("http://localhost/");
+      assertEquals(docRes.status, 200);
+      const html = await docRes.text();
+      const embedded = html.match(
+        /__juniperHydrationData = (.*?); await client\.hydrate\(\)/,
+      );
+      assertExists(embedded);
+      const hydrationData = deserializeHydrationData(
+        JSON.parse(embedded[1]) as SerializedHydrationData,
+      );
+      assertEquals(hydrationData.buildId, buildId);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("omits the header when the project has no client build output", async () => {
+    const dir = await makeProject();
+    try {
+      const server = makeServer(dir);
+      const res = await server.request("http://localhost/", {
+        headers: { "X-Juniper-Route-Id": "/" },
+      });
+      assertEquals(res.status, 200);
+      assertEquals(res.headers.get("X-Juniper-Build"), null);
+      await res.body?.cancel();
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("does not stamp document responses", async () => {
+    const dir = await makeProject(`console.log("build a");`);
+    try {
+      const server = makeServer(dir);
+      const res = await server.request("http://localhost/");
+      assertEquals(res.status, 200);
+      assertEquals(res.headers.get("X-Juniper-Build"), null);
+      await res.body?.cancel();
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("derives the id from the build content, identically per content", async () => {
+    const dirA = await makeProject("a");
+    const dirB = await makeProject("b");
+    const dirA2 = await makeProject("a");
+    try {
+      const idA = await getBuildId(dirA);
+      const idB = await getBuildId(dirB);
+      const idA2 = await getBuildId(dirA2);
+      assertExists(idA);
+      assertExists(idB);
+      assertNotEquals(idA, idB);
+      assertEquals(idA2, idA);
+    } finally {
+      await Deno.remove(dirA, { recursive: true });
+      await Deno.remove(dirB, { recursive: true });
+      await Deno.remove(dirA2, { recursive: true });
     }
   });
 });

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -20,6 +20,7 @@ import { getInstance } from "./utils/otel.ts";
 import {
   buildApp,
   createHandlers,
+  getBuildId,
   isRedirectResponse,
   mergeServerRoutes,
   toRedirectEnvelope,
@@ -86,12 +87,23 @@ export function createServer<
 
   appWrapper.use(async (c, next) => {
     c.set("context", new RouterContextProvider());
+    const buildId = await getBuildId(projectRoot);
+    if (buildId) c.set("buildId", buildId);
     await next();
+    const isDataRequest = c.req.header("X-Juniper-Route-Id") !== undefined;
     // Data-mode requests (with `X-Juniper-Route-Id`) expect a redirect envelope, not a raw 3xx that `fetch` would silently follow.
-    if (c.req.header("X-Juniper-Route-Id") && isRedirectResponse(c.res)) {
+    if (isDataRequest && isRedirectResponse(c.res)) {
       c.res = toRedirectEnvelope(c.res);
       c.res.headers.delete("Location");
       c.res.headers.delete("X-Remix-Reload-Document");
+    }
+    if (isDataRequest && buildId) {
+      try {
+        c.res.headers.set("X-Juniper-Build", buildId);
+      } catch {
+        c.res = new Response(c.res.body, c.res);
+        c.res.headers.set("X-Juniper-Build", buildId);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #112, #113, #114 — the juniper half of udibo/udibo#679 (tabs open across a deployment ending up wedged: dead chunk requests, silent half-hydrated pages, no recovery).

A tab from build N references hashed route chunks build N+1 no longer serves. Juniper's only defense was a loop-guarded `location.reload()` after an import already failed; React Router 7.3+ and Next.js both detect the skew proactively and recover by document navigation. This PR closes the gap with three interlocking changes:

## Changes

- **Reactive recovery navigates to the destination** (#112): `createLazyRoute` failure now `location.assign`s the in-flight navigation's target (from the router registered at hydrate; falls back to `location.href`) instead of reloading the current URL. The server can always SSR the destination, so the user's intent completes in one hop. Loop guard unchanged.
- **Proactive skew detection** (#113): `createServer` derives a build id (content hash of `public/build/main.js`, cached per process — content-derived so every instance of a deployment agrees), embeds it in hydration data, and stamps `X-Juniper-Build` on data-mode responses. `fetchServerData` compares ids on loader (GET) fetches; a mismatch turns the navigation into a document navigation via the existing hold-pending pattern, loop-guarded. Actions are accepted as-is (the action already ran). Missing id on either side leaves the check inert, so old/new clients and servers interoperate.
- **Hydration survives a dead chunk** (#114): `hydrate()` catches `loadLazyMatches` failure and still creates the router, so React Router re-attempts the lazy load and surfaces the error in the nearest ErrorBoundary instead of leaving SSR content with no interactivity. The boundary's `resetErrorBoundary` performs a **document** navigation when the error is a failed module import (`isModuleLoadError`) — browsers cache a failed dynamic import for the document's lifetime, so a client-side retry can never succeed.

## Testing

- Unit tests for all three behaviors: destination-aware recovery (in-flight, settled, no-router fallback, loop guard), skew detection (mismatch → held navigation + assign, match → guard cleared, missing header ignored, actions untouched, guard trip), `isModuleLoadError` per-browser messages, build id (header + hydration-data agreement, content-derived identity, absent without build output, never on document responses), and hydration-data `buildId` round-trip.
- Skew detection and destination navigation were mutation-tested (reverting each change fails exactly the tests named for it).
- Verified end to end in a real browser against the udibo app consuming this source: a missing chunk now recovers via document navigation to the destination; when the server keeps failing, the guard trips and an error page with a working "Try again" renders (previously: silently dead page); after a simulated deploy (changed `main.js`, restarted server), a stale tab's first client-side navigation became a document navigation and self-healed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)