### PR TITLE
fix: support native Windows build paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,9 @@ jobs:
     name: Test on ${{ matrix.os }}
     needs: [format-and-lint]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
@@ -48,6 +50,10 @@ jobs:
           cache: false
       - name: Install dependencies
         run: deno ci
+      - name: Build minimal production application
+        run: deno task build:prod:minimal
+      - name: Build Tailwind production application
+        run: deno task build:prod:tailwindcss
       - name: Run Juniper tests with coverage (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: deno task test --coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,25 @@ Before contributing, ensure you have:
 - A code editor (VS Code with the Deno extension is recommended)
 - Docker (optional, for OpenTelemetry development)
 
+### Windows and Ubuntu
+
+Use a current stable Deno 2 release. The same `deno task` commands work in
+PowerShell and Bash; task commands use Deno's portable shell. Keep separate
+checkouts and `node_modules` directories for native Windows and WSL/Ubuntu.
+
+The repository attributes and editor defaults keep source files on LF. Configure
+a standalone clone locally as follows (Udibo's setup does this for its
+submodules):
+
+```sh
+git config --local core.autocrlf false
+git config --local core.eol lf
+git config --local core.safecrlf true
+```
+
+Docker is needed for the Postgres template tests and optional telemetry. The
+framework, minimal, Tailwind, TanStack, and blog suites need no database.
+
 ### Development Setup
 
 1. **Fork the repository** on GitHub
@@ -32,7 +51,7 @@ Before contributing, ensure you have:
 
 3. **Install dependencies:**
    ```bash
-   deno install
+   deno install --frozen
    ```
 
 4. **Run the example application:**
@@ -384,3 +403,7 @@ Releases are fully automated using
 - **Documentation** - Check the [docs](docs/) folder
 
 Thank you for contributing to Juniper!
+
+## Changelog
+
+- **2026-09-05** — Added native Windows/Ubuntu setup and LF guidance.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -6,6 +6,20 @@ Juniper projects work seamlessly with continuous integration and deployment
 pipelines. This guide covers setting up GitHub Actions for automated testing,
 linting, and deployment.
 
+## Juniper's compatibility checks
+
+The framework's `.github/workflows/ci-cd.yml` runs tests on Ubuntu, macOS, and
+Windows. Windows uses `setup-deno` with caching disabled. The matrix also builds
+the minimal and Tailwind production applications, exercising real CLI builds and
+CSS entries; a failed platform does not cancel the others. The database-backed
+Postgres template remains a separate Ubuntu job.
+
+Relative build entries such as `./main.css` resolve from the project root on
+every platform, including directory names containing spaces. Run both
+`deno task test` and `deno task build:prod:tailwindcss` when changing the
+builder. The generic application CI example below is independent of this
+framework matrix.
+
 ## GitHub Actions
 
 ### Workflow Configuration
@@ -385,3 +399,8 @@ jobs:
 
 - [Testing](testing.md) - Testing utilities and patterns
 - [Configuration](configuration.md) - Project and build configuration
+
+## Changelog
+
+- **2026-09-05** — Documented platform coverage and production-build checks for
+  Windows CSS entry failures.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -402,5 +402,9 @@ jobs:
 
 ## Changelog
 
+- **2026-09-05** — Tailwind build and dev permission profiles allow only the
+  `osRelease` system query needed by jiti's Windows terminal-color detection.
+  Reproduce CI builds without `NO_COLOR` or `TERM=dumb`, which bypass that
+  query.
 - **2026-09-05** — Documented platform coverage and production-build checks for
   Windows CSS entry failures.

--- a/example/deno.json
+++ b/example/deno.json
@@ -71,7 +71,8 @@
       "read": true,
       "write": true,
       "run": true,
-      "ffi": true
+      "ffi": true,
+      "sys": ["osRelease"]
     },
     "dev": {
       "env": true,
@@ -79,7 +80,8 @@
       "write": true,
       "net": true,
       "run": true,
-      "ffi": true
+      "ffi": true,
+      "sys": ["osRelease"]
     },
     "test": {
       "env": true,

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -21,6 +21,42 @@ const exampleDir = path.resolve(
 );
 
 describe("Builder", () => {
+  it("builds relative, absolute, and glob CSS entries from a project directory containing spaces", async () => {
+    const projectRoot = await Deno.makeTempDir({ prefix: "juniper build " });
+    try {
+      await Deno.writeTextFile(path.join(projectRoot, "deno.json"), "{}");
+      await Deno.writeTextFile(
+        path.join(projectRoot, "main.tsx"),
+        "export const value = 1;",
+      );
+      await Deno.writeTextFile(
+        path.join(projectRoot, "main.css"),
+        "body { color: red; }",
+      );
+      for (
+        const entry of [
+          "./main.css",
+          path.join(projectRoot, "main.css"),
+          "./*.css",
+        ]
+      ) {
+        await using builder = new Builder({
+          projectRoot,
+          entryPoints: [entry],
+          write: false,
+        });
+        const result = await builder.build();
+        assertEquals(result.errors, []);
+        const css = result.outputFiles?.find((file) =>
+          file.path.endsWith("main.css")
+        );
+        assertEquals(css?.text.includes("red"), true);
+      }
+    } finally {
+      await Deno.remove(projectRoot, { recursive: true });
+    }
+  });
+
   describe("internal helpers (_build)", () => {
     it("should identify client route types (dynamic and catchall)", () => {
       assertEquals(isClientDynamicRoute("[id].tsx"), true);

--- a/src/build.ts
+++ b/src/build.ts
@@ -71,6 +71,7 @@ export interface BuildOptions {
    * - All CSS files in routes: ["./routes/**\/*.css"]
    * - Multiple entry points: ["./styles/main.css", "./workers/sw.ts"]
    *
+   * Relative entries are resolved from the project root on every platform.
    * Built files will be placed in the public/build directory.
    * Defaults to an empty array.
    */
@@ -162,7 +163,7 @@ export class Builder implements AsyncDisposable {
   readonly ignorePaths: string[];
   /** Absolute output directory for built assets (`public/build`). */
   readonly outdir: string;
-  /** All esbuild entry points: any extra entries plus the main client entry. */
+  /** Absolute esbuild entry paths: extra entries plus the main client entry. */
   readonly entryPoints: string[];
   /** Whether build output is written to disk; `false` is used in tests. */
   protected write: boolean;
@@ -196,7 +197,12 @@ export class Builder implements AsyncDisposable {
       options.configPath ?? "./deno.json",
     );
     this.entryPoint = path.resolve(this.projectRoot, "./main.tsx");
-    this.entryPoints = [...(options.entryPoints ?? []), this.entryPoint];
+    this.entryPoints = [
+      ...(options.entryPoints ?? []).map((entry) =>
+        path.resolve(this.projectRoot, entry)
+      ),
+      this.entryPoint,
+    ];
     this.plugins = [...(options.plugins ?? [])];
     this.outdir = path.resolve(this.publicPath, "build");
     this.serverPath = path.resolve(this.projectRoot, "./main.ts");
@@ -494,10 +500,6 @@ export const client = new Client(${routesConfigString});
           await this.buildMainClientEntrypoint();
         }
 
-        const normalizedEntryPoints = Deno.build.os === "windows"
-          ? this.entryPoints.map((p) => path.toFileUrl(p).href)
-          : this.entryPoints;
-
         this.context = await esbuild.context({
           plugins: [
             reactCompilerPlugin({
@@ -507,7 +509,7 @@ export const client = new Client(${routesConfigString});
             denoPlugin({ configPath }),
           ],
           absWorkingDir: path.dirname(configPath),
-          entryPoints: normalizedEntryPoints,
+          entryPoints: this.entryPoints,
           outdir: this.outdir,
           outbase: this.projectRoot,
           bundle: true,

--- a/templates/tailwindcss/deno.json
+++ b/templates/tailwindcss/deno.json
@@ -63,7 +63,8 @@
       "read": true,
       "write": true,
       "run": true,
-      "ffi": true
+      "ffi": true,
+      "sys": ["osRelease"]
     },
     "dev": {
       "env": true,
@@ -71,7 +72,8 @@
       "write": true,
       "net": true,
       "run": true,
-      "ffi": true
+      "ffi": true,
+      "sys": ["osRelease"]
     },
     "test": {
       "env": true,


### PR DESCRIPTION
## Summary

Fix native Windows builds that pass CSS entry points through PostCSS, and preserve LF text files on Windows and Ubuntu.

## Changes

- Resolve relative, absolute, and glob entry points against the project root and pass native paths to esbuild.
- Cover projects whose paths contain spaces with a build regression test.
- Add minimal and Tailwind production builds to the existing Windows, Ubuntu, and macOS CI matrix.
- Document native development and add Git/editor line-ending rules.

## Testing

- Windows and Ubuntu: `deno task check`, `deno task test --parallel --reporter=dot` (24 passed, 292 steps), main example and Tailwind production builds.
- Regression test failed before the fix and passed after it.

## Closes

Nothing.