### PR TITLE
fix(testing): preserve form submission behavior

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2256,6 +2256,7 @@
           "npm:@modelcontextprotocol/sdk@^1.29.0",
           "npm:@opentelemetry/api@^1.9.1",
           "npm:@testing-library/react@^16.3.2",
+          "npm:@testing-library/user-event@^14.6.1",
           "npm:@types/react@^19.2.16",
           "npm:babel-plugin-react-compiler@1",
           "npm:cbor2@^2.3.0",

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -1,10 +1,11 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import * as path from "@std/path";
-import { describe, it } from "@std/testing/bdd";
+import { afterAll, describe, it } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
 
 import { Builder } from "./build.ts";
 import { isSnapshotMode } from "./utils/testing.ts";
+import { observeChildProcesses } from "./utils/_testing-processes.ts";
 
 import { deno } from "./deno.ts";
 import {
@@ -20,7 +21,12 @@ const exampleDir = path.resolve(
   "../example",
 );
 
+const spawnedProcesses = observeChildProcesses();
+
 describe("Builder", () => {
+  afterAll(async () => {
+    await spawnedProcesses[Symbol.asyncDispose]();
+  });
   it("builds relative, absolute, and glob CSS entries from a project directory containing spaces", async () => {
     const projectRoot = await Deno.makeTempDir({ prefix: "juniper build " });
     try {

--- a/src/deno.json
+++ b/src/deno.json
@@ -50,6 +50,7 @@
     "react-error-boundary": "npm:react-error-boundary@^6.1.2",
     "react-router": "npm:react-router@^8.3.0",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
+    "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1",
     "global-jsdom": "npm:global-jsdom@^29.0.0"
   },
   "compilerOptions": {

--- a/src/utils/_testing-processes.ts
+++ b/src/utils/_testing-processes.ts
@@ -1,0 +1,24 @@
+import childProcess from "node:child_process";
+import { once } from "node:events";
+import { stub } from "@std/testing/mock";
+
+/** Await real child exits after the test has asked its services to stop. */
+export function observeChildProcesses(): AsyncDisposable {
+  const spawn = childProcess.spawn;
+  const children = new Map<childProcess.ChildProcess, Promise<unknown>>();
+  const observer = stub(childProcess, "spawn", (...args) => {
+    const child = spawn(...args);
+    children.set(child, once(child, "close"));
+    return child;
+  });
+  return {
+    async [Symbol.asyncDispose]() {
+      try {
+        for (const child of children.keys()) child.ref();
+        await Promise.all(children.values());
+      } finally {
+        observer.restore();
+      }
+    },
+  };
+}

--- a/src/utils/form-data.test.ts
+++ b/src/utils/form-data.test.ts
@@ -1,0 +1,163 @@
+import "@udibo/juniper/utils/global-jsdom";
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { userEvent } from "@testing-library/user-event";
+
+function formFrom(html: string): HTMLFormElement {
+  document.body.innerHTML = html;
+  return document.querySelector("form")!;
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe("FormData from a JSDOM form", () => {
+  it("submits checked controls and preserves repeated names in document order", () => {
+    const form = formFrom(`<form>
+      <input name="choice" type="checkbox" value="unchecked">
+      <input name="choice" type="checkbox" value="first" checked>
+      <input name="choice" type="checkbox" checked>
+      <input name="radio" type="radio" value="no">
+      <input name="radio" type="radio" value="yes" checked>
+      <textarea name="choice">last</textarea>
+    </form>`);
+    assertEquals([...new FormData(form)], [
+      ["choice", "first"],
+      ["choice", "on"],
+      ["radio", "yes"],
+      ["choice", "last"],
+    ]);
+  });
+
+  it("omits disabled and datalist controls but keeps the first legend and readonly values", () => {
+    const form = formFrom(`<form>
+      <input name="disabled" disabled value="no">
+      <fieldset disabled>
+        <legend><input name="legend" value="yes"></legend>
+        <input name="fieldset" value="no">
+        <legend><input name="secondLegend" value="no"></legend>
+      </fieldset>
+      <datalist><input name="suggestion" value="no"></datalist>
+      <input name="readonly" readonly value="yes">
+      <input value="unnamed">
+    </form>`);
+    assertEquals([...new FormData(form)], [["legend", "yes"], [
+      "readonly",
+      "yes",
+    ]]);
+  });
+
+  it("submits every selected enabled option and no unselected options", () => {
+    const form = formFrom(`<form><select name="scope" multiple>
+      <option value="read" selected>Read</option>
+      <option value="write" selected>Write</option>
+      <option value="unselected">Unselected</option>
+      <option value="disabled" selected disabled>Disabled</option>
+      <optgroup disabled><option value="group" selected>Group</option></optgroup>
+    </select></form>`);
+    assertEquals(new FormData(form).getAll("scope"), ["read", "write"]);
+  });
+
+  it("includes only the chosen submitter, including an associated external button", () => {
+    const form = formFrom(`<input form="entry" name="outside" value="before">
+      <form id="entry">
+        <input name="title" value="draft">
+        <button name="intent" value="save">Save</button>
+        <input name="reset" type="reset" value="Reset">
+        <input name="button" type="button" value="Button">
+        <input name="elsewhere" form="other" value="no">
+      </form>
+      <button id="publish" form="entry" name="intent" value="publish">Publish</button>
+      <form id="other"></form>`);
+    const submitter = document.getElementById("publish")!;
+    assertEquals([...new FormData(form)], [["outside", "before"], [
+      "title",
+      "draft",
+    ]]);
+    assertEquals([...new FormData(form, submitter)], [
+      ["outside", "before"],
+      ["title", "draft"],
+      ["intent", "publish"],
+    ]);
+  });
+
+  it("rejects a non-submit control or a submitter owned by another form", () => {
+    const form = formFrom(`<form><input id="text"></form>
+      <form><button id="foreign">Other</button></form>`);
+    assertThrows(
+      () => new FormData(form, document.getElementById("text")!),
+      TypeError,
+    );
+    const error = assertThrows(
+      () => new FormData(form, document.getElementById("foreign")!),
+      DOMException,
+    );
+    assertEquals(error.name, "NotFoundError");
+  });
+
+  it("includes image coordinates only for the selected image submitter", () => {
+    const form = formFrom(
+      `<form><input type="image" name="position" id="image"></form>`,
+    );
+    assertEquals([...new FormData(form)], []);
+    assertEquals([...new FormData(form, document.getElementById("image")!)], [
+      ["position.x", "0"],
+      ["position.y", "0"],
+    ]);
+  });
+
+  it("represents an empty file input with an empty file rather than text", async () => {
+    const form = formFrom(`<form><input type="file" name="attachment"></form>`);
+    const file = new FormData(form).get("attachment");
+    assert(file instanceof File);
+    assertEquals([file.name, file.type, file.size], [
+      "",
+      "application/octet-stream",
+      0,
+    ]);
+    assertEquals(await file.text(), "");
+  });
+
+  it("rejects JSDOM file objects instead of silently corrupting their bytes", async () => {
+    const form = formFrom(`<form><input type="file" name="attachment"></form>`);
+    await userEvent.setup().upload(
+      form.querySelector("input")!,
+      new document.defaultView!.File(["bytes"], "jsdom.txt"),
+    );
+    assertThrows(
+      () => new FormData(form),
+      TypeError,
+      "global File constructor",
+    );
+  });
+
+  it("preserves uploaded bytes and filenames through a Deno multipart request", async () => {
+    const form = formFrom(
+      `<form><input type="file" name="attachment" multiple></form>`,
+    );
+    const first = new File([new Uint8Array([0, 255, 10, 13])], "first.bin", {
+      type: "application/octet-stream",
+    });
+    const second = new File(["hello"], "second.txt", { type: "text/plain" });
+    await userEvent.setup().upload(form.querySelector("input")!, [
+      first,
+      second,
+    ]);
+    const request = new Request("http://localhost/upload", {
+      method: "POST",
+      body: new FormData(form),
+    });
+    const files = (await request.formData()).getAll("attachment");
+    assertEquals(files.length, 2);
+    assert(files[0] instanceof File && files[1] instanceof File);
+    assertEquals([files[0], files[1]].map((file) => [file.name, file.type]), [[
+      "first.bin",
+      "application/octet-stream",
+    ], ["second.txt", "text/plain"]]);
+    assertEquals(
+      new Uint8Array(await files[0].arrayBuffer()),
+      new Uint8Array([0, 255, 10, 13]),
+    );
+    assertEquals(await files[1].text(), "hello");
+  });
+});

--- a/src/utils/react-compiler-plugin.test.ts
+++ b/src/utils/react-compiler-plugin.test.ts
@@ -1,15 +1,17 @@
-import { delay } from "@std/async/delay";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import * as path from "@std/path";
 import { afterAll, describe, it } from "@std/testing/bdd";
 import * as esbuild from "esbuild";
 
 import { reactCompilerPlugin } from "./react-compiler-plugin.ts";
+import { observeChildProcesses } from "./_testing-processes.ts";
+
+const spawnedProcesses = observeChildProcesses();
 
 describe("reactCompilerPlugin", () => {
   afterAll(async () => {
     await esbuild.stop();
-    await delay(10);
+    await spawnedProcesses[Symbol.asyncDispose]();
   });
 
   describe("basic functionality", () => {

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -508,20 +508,90 @@ export function fetchResolver(): [ResolveFetch, FakeFetch] {
   return [resolveFetch, fakeFetch];
 }
 
+type FormControl =
+  | HTMLInputElement
+  | HTMLButtonElement
+  | HTMLTextAreaElement
+  | HTMLSelectElement;
+
+function isSubmitButton(element: HTMLElement): boolean {
+  return element.localName === "button" &&
+      (element as HTMLButtonElement).type === "submit" ||
+    element.localName === "input" &&
+      ["submit", "image"].includes((element as HTMLInputElement).type);
+}
+
 class MockFormData extends FormData {
-  constructor(form?: HTMLFormElement) {
+  constructor(form?: HTMLFormElement, submitter: HTMLElement | null = null) {
     super();
-    if (form) {
-      const inputs = form.querySelectorAll("input, textarea, select");
-      inputs.forEach((input) => {
-        const el = input as
-          | HTMLInputElement
-          | HTMLTextAreaElement
-          | HTMLSelectElement;
-        if (el.name) {
-          this.append(el.name, el.value);
+    if (form === undefined) return;
+    if (!form || form.localName !== "form") {
+      throw new TypeError("Expected an HTMLFormElement");
+    }
+    if (submitter !== null) {
+      if (!isSubmitButton(submitter)) {
+        throw new TypeError("The specified element is not a submit button");
+      }
+      if ((submitter as HTMLButtonElement | HTMLInputElement).form !== form) {
+        throw new DOMException(
+          "The submitter does not belong to this form",
+          "NotFoundError",
+        );
+      }
+    }
+
+    const root = form.getRootNode() as ParentNode;
+    const controls = root.querySelectorAll<FormControl>(
+      "button, input, textarea, select",
+    );
+    for (const control of controls) {
+      if (
+        control.form !== form || control.matches(":disabled") ||
+        control.closest("datalist")
+      ) continue;
+      if (
+        ["submit", "image", "reset", "button"].includes(control.type) &&
+        control !== submitter
+      ) continue;
+      if (
+        ["checkbox", "radio"].includes(control.type) &&
+        !(control as HTMLInputElement).checked
+      ) continue;
+
+      const name = control.name;
+      if (control.localName === "input" && control.type === "image") {
+        const prefix = name ? `${name}.` : "";
+        this.append(`${prefix}x`, "0");
+        this.append(`${prefix}y`, "0");
+        continue;
+      }
+      if (!name) continue;
+      if (control.localName === "select") {
+        for (const option of (control as HTMLSelectElement).selectedOptions) {
+          if (!option.disabled && !option.closest("optgroup[disabled]")) {
+            this.append(name, option.value);
+          }
         }
-      });
+      } else if (control.localName === "input" && control.type === "file") {
+        const files = (control as HTMLInputElement).files;
+        if (files?.length) {
+          for (const file of files) {
+            if (!(file instanceof Blob)) {
+              throw new TypeError(
+                "Upload files created with the global File constructor, not window.File",
+              );
+            }
+            this.append(name, file, file.name);
+          }
+        } else {
+          this.append(
+            name,
+            new File([], "", { type: "application/octet-stream" }),
+          );
+        }
+      } else {
+        this.append(name, control.value);
+      }
     }
   }
 }
@@ -540,8 +610,10 @@ export interface FormDataStub extends Disposable {
  *
  * This is necessary because Deno's native FormData constructor throws
  * "Illegal constructor" when passed a JSDOM HTMLFormElement. This stub
- * replaces FormData with a compatible implementation that manually extracts
- * form field values.
+ * replaces FormData with a Deno-compatible implementation of successful form
+ * controls, including the selected submitter and controls associated by `form`.
+ * Create uploaded files with the global `File` constructor, not `window.File`,
+ * so their bytes remain compatible with Deno's multipart request bodies.
  *
  * **Note:** If you are using `@udibo/juniper/utils/global-jsdom` to set up JSDOM,
  * this function is already called automatically and you do not need to call it yourself.


### PR DESCRIPTION
## Summary

The JSDOM FormData shim included unchecked and disabled controls, dropped multiple selections and submitters, and converted file inputs to strings. It now preserves the submitted values and multipart file bytes for these cases, so route tests can detect real form-handling regressions.

## Changes

- Respect checked state, disabled fieldsets and options, form ownership, repeated names, and the selected submitter. Validate submitter ownership and handle image coordinates.
- Preserve files created with the global File constructor through Deno request serialization. Reject incompatible JSDOM File objects explicitly instead of corrupting their contents.
- Add nine focused form scenarios; the initial eight regressions all failed before the fix.
- Replace compiler-test cleanup's 10 ms timing guess with observation of actual child-process exits, and use the same cleanup for Builder tests.

## Testing

- `deno task check`
- `deno task test --parallel --reporter=dot --trace-leaks`: 25 tests, 302 steps, zero failures, sanitizers enabled.
- File tests round-trip binary content, names, and MIME types through a Deno multipart request.

## Closes

Nothing.