### PR TITLE
feat: add a before-hydration hook

### DIFF
--- a/src/client.hydration.test.tsx
+++ b/src/client.hydration.test.tsx
@@ -1,0 +1,188 @@
+import "@udibo/juniper/utils/global-jsdom";
+
+import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
+import { it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
+import { waitFor } from "@testing-library/react";
+import globalJsdom from "global-jsdom";
+import { act } from "react";
+import { renderToString } from "react-dom/server";
+
+import { Client } from "@udibo/juniper/client";
+import type { RootRouteModule } from "@udibo/juniper";
+
+import { App, registerRouter } from "./_client.tsx";
+import { simulateBrowser } from "./utils/testing.internal.ts";
+
+for (const lazy of [false, true]) {
+  it(
+    `captures served edits at scheduled hydration for a ${
+      lazy ? "lazy" : "eager"
+    } root`,
+    simulateBrowser({ matches: [{ id: "/" }] }, async () => {
+      const cleanup = globalJsdom(undefined, { url: "http://localhost:8000/" });
+      let scheduled: IdleRequestCallback | undefined;
+      const previousIdle = globalThis.requestIdleCallback;
+      globalThis.requestIdleCallback = (callback) => {
+        scheduled = callback;
+        return 1;
+      };
+      let capture = "";
+      let calls = 0;
+      let cleanups = 0;
+      let loads = 0;
+      const route = {
+        default: () => (
+          <textarea
+            defaultValue="seed"
+            ref={(node) => {
+              if (node && capture) node.value = capture;
+            }}
+          />
+        ),
+        beforeHydrate(doc: Document): () => void {
+          calls++;
+          capture = doc.querySelector("textarea")!.value;
+          return () => {
+            cleanups++;
+          };
+        },
+      } satisfies RootRouteModule;
+      const client = new Client({
+        path: "/",
+        main: lazy
+          ? () => {
+            loads++;
+            return Promise.resolve(route);
+          }
+          : route,
+      });
+      document.documentElement.innerHTML = renderToString(
+        <App>
+          <route.default />
+        </App>,
+      ).replace(/^<html[^>]*>|<\/html>$/g, "");
+      try {
+        await client.hydrate();
+        assertEquals(calls, 0);
+        assertExists(scheduled);
+        const textarea = document.querySelector("textarea")!;
+        textarea.value = "typed while idle";
+        await act(() =>
+          scheduled!({ didTimeout: false, timeRemaining: () => 50 })
+        );
+        assertEquals(calls, 1);
+        assertEquals(capture, "typed while idle");
+        assert(document.querySelector("textarea") === textarea);
+        assertEquals(textarea.value, "typed while idle");
+        assertEquals(loads, lazy ? 1 : 0);
+        document.defaultView!.dispatchEvent(
+          new document.defaultView!.PageTransitionEvent("pagehide", {
+            persisted: true,
+          }),
+        );
+        assertEquals(cleanups, 0);
+        document.defaultView!.dispatchEvent(
+          new document.defaultView!.PageTransitionEvent("pagehide", {
+            persisted: false,
+          }),
+        );
+        document.defaultView!.dispatchEvent(
+          new document.defaultView!.PageTransitionEvent("pagehide", {
+            persisted: false,
+          }),
+        );
+        assertEquals(cleanups, 1);
+      } finally {
+        if (previousIdle) globalThis.requestIdleCallback = previousIdle;
+        else Reflect.deleteProperty(globalThis, "requestIdleCallback");
+        registerRouter(undefined);
+        document.defaultView!.close();
+        cleanup();
+      }
+    }),
+  );
+}
+
+for (const failure of ["caught", "uncaught", "hook"] as const) {
+  it(
+    `handles ${failure} failure at hydration without discarding recoverable work`,
+    simulateBrowser({ matches: [{ id: "/" }] }, async () => {
+      const cleanup = globalJsdom(undefined, { url: "http://localhost:8000/" });
+      using _errors = stub(console, "error", () => {});
+      let scheduled: IdleRequestCallback | undefined;
+      const previousIdle = globalThis.requestIdleCallback;
+      globalThis.requestIdleCallback = (callback) => {
+        scheduled = callback;
+        return 1;
+      };
+      let cleanups = 0;
+      let renders = 0;
+      let fail = false;
+      const route: RootRouteModule = {
+        default: () => {
+          renders++;
+          if (fail && failure === "caught") throw new Error("route failed");
+          return <p>Served</p>;
+        },
+        ErrorBoundary: () => <p>Recovered</p>,
+        beforeHydrate: () => {
+          if (failure === "hook") throw new Error("capture failed");
+          return () => {
+            cleanups++;
+          };
+        },
+      };
+      const client = new Client({ path: "/", main: route });
+      if (failure === "uncaught") {
+        client.htmlProps = {
+          get lang(): string {
+            throw new Error("document props failed");
+          },
+        };
+      }
+      document.documentElement.innerHTML = renderToString(
+        <App>
+          <p>Served</p>
+        </App>,
+      ).replace(/^<html[^>]*>|<\/html>$/g, "");
+      try {
+        await client.hydrate();
+        assertExists(scheduled);
+        fail = true;
+        const hydrate = () =>
+          scheduled!({ didTimeout: false, timeRemaining: () => 50 });
+        if (failure === "hook") {
+          assertThrows(hydrate, Error, "capture failed");
+          assertEquals(renders, 0);
+          assertEquals(document.querySelector("p")?.textContent, "Served");
+        } else {
+          hydrate();
+          if (failure === "caught") {
+            await waitFor(() =>
+              assertEquals(
+                document.querySelector("p")?.textContent,
+                "Recovered",
+              )
+            );
+            assertEquals(cleanups, 0);
+          } else {
+            await waitFor(() => assertEquals(cleanups, 1));
+          }
+          document.defaultView!.dispatchEvent(
+            new document.defaultView!.PageTransitionEvent("pagehide", {
+              persisted: false,
+            }),
+          );
+          assertEquals(cleanups, 1);
+        }
+      } finally {
+        if (previousIdle) globalThis.requestIdleCallback = previousIdle;
+        else Reflect.deleteProperty(globalThis, "requestIdleCallback");
+        registerRouter(undefined);
+        document.defaultView!.close();
+        cleanup();
+      }
+    }),
+  );
+}

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -118,6 +118,8 @@ export class Client {
   /** Props to apply to the `<html>` element, from root route's htmlProps export. */
   htmlProps?: HtmlProps;
 
+  #rootModule?: RootRouteModule;
+
   /**
    * Builds the client route tree from a root route, ready to
    * {@linkcode Client.hydrate}.
@@ -132,6 +134,7 @@ export class Client {
     this.routeObjectMap = new Map();
 
     if (rootRoute.main && typeof rootRoute.main !== "function") {
+      this.#rootModule = rootRoute.main;
       this.htmlProps = rootRoute.main.htmlProps;
     }
 
@@ -145,8 +148,15 @@ export class Client {
       const routeId = routeObject.id!;
 
       if (typeof route.main === "function") {
+        const loadModule = route.main;
         routeObject.lazy = createLazyRoute(
-          route.main,
+          route === rootRoute
+            ? async () => {
+              const module = await (loadModule as RootRouteModuleLoader)();
+              this.#rootModule = module;
+              return module;
+            }
+            : loadModule,
           route.server,
           routeId,
         );
@@ -320,6 +330,7 @@ export class Client {
     registerRouter(router);
 
     const htmlProps = this.htmlProps;
+    const beforeHydrate = this.#rootModule?.beforeHydrate;
     function HydratedApp() {
       const [routerContext] = useState(() => context);
       return (
@@ -334,19 +345,38 @@ export class Client {
     }
 
     function hydrate() {
+      let dispose = beforeHydrate?.(document);
+      function release(): void {
+        document.defaultView?.removeEventListener("pagehide", onPageHide);
+        const cleanup = dispose;
+        dispose = undefined;
+        cleanup?.();
+      }
+      function onPageHide(event: PageTransitionEvent): void {
+        if (!event.persisted) release();
+      }
+      if (dispose) {
+        document.defaultView?.addEventListener("pagehide", onPageHide);
+      }
       startTransition(() => {
-        hydrateRoot(
-          document,
-          <HydratedApp />,
-          {
-            onUncaughtError: (error: unknown) => {
-              console.error("hydrate onUncaughtError", error);
+        try {
+          hydrateRoot(
+            document,
+            <HydratedApp />,
+            {
+              onUncaughtError: (error: unknown) => {
+                release();
+                console.error("hydrate onUncaughtError", error);
+              },
+              onCaughtError: (error: unknown) => {
+                console.error("hydrate onCaughtError", error);
+              },
             },
-            onCaughtError: (error: unknown) => {
-              console.error("hydrate onCaughtError", error);
-            },
-          },
-        );
+          );
+        } catch (error) {
+          release();
+          throw error;
+        }
       });
     }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1084,4 +1084,25 @@ export interface RootRouteModule<
    * ```
    */
   htmlProps?: HtmlProps;
+  /**
+   * Runs synchronously in the browser immediately before React hydration,
+   * after route loading and the idle delay. Use it to capture served DOM state
+   * that a component will consume when its ref attaches. It must not change
+   * markup or return a promise.
+   *
+   * An optional idempotent cleanup runs once on fatal hydration failure or permanent
+   * page departure. Caught errors and bfcache suspension do not dispose it;
+   * the hook should also release resources when its own work completes.
+   * A thrown error prevents hydration.
+   *
+   * @param document - The application document about to hydrate.
+   * @returns Optional cleanup for pending work.
+   * @example
+   * ```tsx
+   * export function beforeHydrate(document: Document): () => void {
+   *   return capturePendingFormEdits(document);
+   * }
+   * ```
+   */
+  beforeHydrate?: (document: Document) => void | (() => void);
 }


### PR DESCRIPTION
## Summary

An application can now export a synchronous `beforeHydrate(document)` hook from its root route to capture served form state immediately before React hydration. This gives components a safe preparation point after lazy route loading and the idle delay, including when their refs attach later during suspended hydration.

## Changes

- Invoke the optional hook for eager and lazy root modules without loading a lazy root twice.
- Accept an idempotent cleanup for fatal hydration failures and permanent page departure; retain pending work through caught errors and bfcache suspension.
- Document the timing and cleanup contract on `RootRouteModule`.

## Testing

Checks and all 30 tests (302 steps) passed. Five real hydration regressions cover eager/lazy roots, capture after the idle delay, current DOM node identity, caught and uncaught errors, hook failure, and one-time cleanup. Independent review found no remaining issues.

Supplemental `deno doc --lint mod.ts client.tsx` reports five existing React Router private-type references; the same five were verified against unchanged main. No finding concerns the new hook.

## Closes

Nothing.
