### PR TITLE
fix: avoid errors during bundle recovery

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -776,7 +776,9 @@ The current page remains visible until the destination is ready. If a deployment
 removed a lazy route bundle, Juniper recovers with a document navigation to the
 destination, including its query and fragment. The route stays pending during
 that recovery so an error boundary does not flash before the new SSR page
-arrives. If the reload guard is exhausted, the error reaches the boundary.
+arrives. If the reload guard is exhausted, the error reaches the boundary. If a
+document navigation is canceled, navigating away and back can retry recovery
+within that same limit.
 
 ### Link Component
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -748,6 +748,36 @@ after 2 attempts, the client stops refreshing.
 
 ## Navigation
 
+### Pending Navigation
+
+Juniper uses `HydrateFallback` for initial client hydration and deferred loader
+data within that route. It cannot provide feedback while that route's module is
+still downloading. For navigation that waits for a route module or a blocking
+server loader, render feedback in an already loaded layout with React Router's
+`useNavigation`:
+
+```tsx
+import { Outlet, useNavigation } from "react-router";
+
+export default function Main() {
+  const navigation = useNavigation();
+  return (
+    <>
+      <p role="status">
+        {navigation.state === "loading" ? "Loading page…" : ""}
+      </p>
+      <Outlet />
+    </>
+  );
+}
+```
+
+The current page remains visible until the destination is ready. If a deployment
+removed a lazy route bundle, Juniper recovers with a document navigation to the
+destination, including its query and fragment. The route stays pending during
+that recovery so an error boundary does not flash before the new SSR page
+arrives. If the reload guard is exhausted, the error reaches the boundary.
+
 ### Link Component
 
 Use the `Link` component for client-side navigation:

--- a/src/_client.tsx
+++ b/src/_client.tsx
@@ -670,15 +670,16 @@ export function createLazyRoute(
       routeFile = await lazyRouteFile();
       clearReloadState(LAZY_LOAD_RELOAD_KEY);
     } catch (error) {
-      if (shouldReload(LAZY_LOAD_RELOAD_KEY)) {
+      const recover = (): Promise<never> => {
+        if (!shouldReload(LAZY_LOAD_RELOAD_KEY)) throw error;
         recordReload(LAZY_LOAD_RELOAD_KEY);
         const destination = recoveryDestination();
         delay(0).then(() => {
           globalThis.location.assign(destination);
         });
         return holdForDocumentNavigation();
-      }
-      throw error;
+      };
+      return activeRouter ? { loader: recover, action: recover } : recover();
     }
     const { middleware: _, ...rest } = createRoute(
       routeFile,

--- a/src/_client.tsx
+++ b/src/_client.tsx
@@ -651,7 +651,8 @@ export function createRoute(
  * destination — the server can always render it, and the fresh document
  * carries the new build's chunk names. Recovery is loop-guarded via
  * `sessionStorage`; once the guard trips the error is left to surface in the
- * nearest ErrorBoundary.
+ * nearest ErrorBoundary. During recovery the route remains pending so the
+ * current page stays visible until the document navigation completes.
  *
  * @param lazyRouteFile - The lazy route file to create a lazy route object from.
  * @param serverFlags - Flags indicating whether the route has server-side loader/action.
@@ -675,6 +676,7 @@ export function createLazyRoute(
         delay(0).then(() => {
           globalThis.location.assign(destination);
         });
+        return holdForDocumentNavigation();
       }
       throw error;
     }

--- a/src/client.test.tsx
+++ b/src/client.test.tsx
@@ -955,6 +955,18 @@ describe("createLazyRoute failure recovery", () => {
     );
   }
 
+  async function recoverFailedLazyRoute(): Promise<unknown> {
+    const route = await failingLazyRoute()();
+    assertExists(route.loader);
+    return route.loader({
+      context: {} as never,
+      params: {},
+      request: new Request("http://localhost/destination"),
+      url: new URL("http://localhost/destination"),
+      pattern: "/destination",
+    });
+  }
+
   async function assertPendingRecovery(
     result: Promise<unknown>,
   ): Promise<void> {
@@ -974,7 +986,7 @@ describe("createLazyRoute failure recovery", () => {
       },
     });
 
-    await assertPendingRecovery(failingLazyRoute()());
+    await assertPendingRecovery(recoverFailedLazyRoute());
 
     assertEquals(assigned, ["/destination?q=1#top"]);
   });
@@ -1004,6 +1016,72 @@ describe("createLazyRoute failure recovery", () => {
     }
   });
 
+  it("retries a canceled document recovery on a later navigation", async () => {
+    const router = createMemoryRouter([{
+      path: "/current",
+      Component: () => <div>Current page</div>,
+    }, {
+      path: "/destination",
+      lazy: failingLazyRoute(),
+    }], { initialEntries: ["/current"] });
+    registerRouter(router);
+    try {
+      await assertPendingRecovery(router.navigate("/destination?q=1#top"));
+      await router.navigate("/current");
+      await assertPendingRecovery(router.navigate("/destination?q=2#retry"));
+      assertEquals(assigned, [
+        "/destination?q=1#top",
+        "/destination?q=2#retry",
+      ]);
+      assertEquals(router.state.errors, null);
+      await router.navigate("/current");
+      await router.navigate("/destination?q=3");
+      assertEquals(assigned.length, 2);
+      assertEquals(Object.values(router.state.errors ?? {}).length, 1);
+      assertEquals(router.state.navigation.state, "idle");
+    } finally {
+      router.dispose();
+    }
+  });
+
+  it("keeps a form navigation pending during document recovery", async () => {
+    const router = createMemoryRouter([{
+      path: "/current",
+      Component: () => <div>Current page</div>,
+    }, {
+      path: "/destination",
+      lazy: failingLazyRoute(),
+    }], { initialEntries: ["/current"] });
+    registerRouter(router);
+    try {
+      await assertPendingRecovery(router.navigate("/destination", {
+        formMethod: "post",
+        formData: new FormData(),
+      }));
+      assertEquals(assigned, ["/destination"]);
+      assertEquals(router.state.location.pathname, "/current");
+      assertEquals(router.state.navigation.state, "submitting");
+      assertEquals(router.state.errors, null);
+    } finally {
+      router.dispose();
+    }
+  });
+
+  it("holds initial lazy matching until the replacement document arrives", async () => {
+    const client = new Client({
+      path: "/",
+      children: [{
+        path: "destination",
+        main: () => Promise.reject(new Error("chunk missing")),
+      }],
+    });
+    await assertPendingRecovery(
+      client.loadLazyMatches([{ id: "/destination" }]),
+    );
+    assertEquals(assigned, ["http://localhost/current"]);
+    assertExists(client.routeObjectMap.get("/destination")?.lazy);
+  });
+
   it("navigates to the settled location when no navigation is in flight", async () => {
     registerRouter({
       state: {
@@ -1012,7 +1090,7 @@ describe("createLazyRoute failure recovery", () => {
       },
     });
 
-    await assertPendingRecovery(failingLazyRoute()());
+    await assertPendingRecovery(recoverFailedLazyRoute());
 
     assertEquals(assigned, ["/current?tab=2"]);
   });

--- a/src/client.test.tsx
+++ b/src/client.test.tsx
@@ -16,7 +16,7 @@ import {
 import { assertSpyCalls, stub } from "@std/testing/mock";
 import { delay } from "@std/async/delay";
 import { HttpError } from "./mod.ts";
-import { Outlet } from "react-router";
+import { createMemoryRouter, Outlet } from "react-router";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 
 import { Client } from "./client.tsx";
@@ -955,6 +955,15 @@ describe("createLazyRoute failure recovery", () => {
     );
   }
 
+  async function assertPendingRecovery(
+    result: Promise<unknown>,
+  ): Promise<void> {
+    let outcome = "pending";
+    result.then(() => outcome = "resolved", () => outcome = "rejected");
+    await delay(10);
+    assertEquals(outcome, "pending");
+  }
+
   it("hard-navigates to the in-flight navigation's destination", async () => {
     registerRouter({
       state: {
@@ -965,10 +974,34 @@ describe("createLazyRoute failure recovery", () => {
       },
     });
 
-    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
-    await delay(1);
+    await assertPendingRecovery(failingLazyRoute()());
 
     assertEquals(assigned, ["/destination?q=1#top"]);
+  });
+
+  it("keeps the current route without publishing an error during document recovery", async () => {
+    const router = createMemoryRouter([{
+      path: "/current",
+      Component: () => <div>Current page</div>,
+    }, {
+      path: "/destination",
+      lazy: failingLazyRoute(),
+    }], { initialEntries: ["/current"] });
+    registerRouter(router);
+    const errors: unknown[] = [];
+    const unsubscribe = router.subscribe((state) => {
+      if (state.errors) errors.push(state.errors);
+    });
+    try {
+      await assertPendingRecovery(router.navigate("/destination?q=1#top"));
+      assertEquals(assigned, ["/destination?q=1#top"]);
+      assertEquals(router.state.location.pathname, "/current");
+      assertEquals(router.state.navigation.state, "loading");
+      assertEquals(errors, []);
+    } finally {
+      unsubscribe();
+      router.dispose();
+    }
   });
 
   it("navigates to the settled location when no navigation is in flight", async () => {
@@ -979,24 +1012,23 @@ describe("createLazyRoute failure recovery", () => {
       },
     });
 
-    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
-    await delay(1);
+    await assertPendingRecovery(failingLazyRoute()());
 
     assertEquals(assigned, ["/current?tab=2"]);
   });
 
   it("falls back to location.href when no router is registered", async () => {
-    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
-    await delay(1);
+    await assertPendingRecovery(failingLazyRoute()());
 
     assertEquals(assigned, ["http://localhost/current"]);
   });
 
   it("stops navigating once the loop guard trips, so the error can surface", async () => {
-    for (let attempt = 0; attempt < 3; attempt++) {
-      await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
-      await delay(1);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await assertPendingRecovery(failingLazyRoute()());
     }
+    await assertRejects(() => failingLazyRoute()(), Error, "chunk missing");
+    await delay(1);
 
     assertEquals(assigned.length, 2);
   });


### PR DESCRIPTION
## Summary

A lazy route bundle removed by a deployment caused an error boundary to flash while Juniper loaded the destination as a fresh SSR document. Keep the current page visible and navigation pending until the replacement document arrives.

## Changes

- Use recovery loaders and actions after hydration, so canceling a document navigation still allows a later navigation to retry.
- Preserve SSR during initial lazy matching, destination paths, queries, fragments, and the existing reload limit.
- Document shared navigation feedback and route hydration fallbacks.

## Testing

- `deno task check`
- `deno task test --parallel --reporter=dot`: 25 passed (306 steps).
- Real-router regressions cover no transient errors, canceled recovery retries, POST navigation, initial lazy matching, and guard exhaustion. Both the original error flash and canceled-recovery regression were reproduced before their fixes.
- The Udibo browser preview exercised missing lazy chunks and delayed navigation.

## Closes

Nothing.
