### PR TITLE
fix(docs): remove guide metadata and history

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,3 @@
----
-title: Juniper Guides
-last_verified: 2026-09-09
----
-
 # Juniper Guides
 
 Juniper renders React routes on Deno, uses Hono for HTTP requests, and uses
@@ -57,8 +52,3 @@ The [JSR API reference](https://jsr.io/@udibo/juniper/doc) documents exported
 types and methods. Guides explain how those APIs fit together. Examples that
 refer to application services assume those services exist; complete test
 examples include their fixtures.
-
-## Changelog
-
-- **2026-09-09** — Added a learning path, full guide index, and execution and
-  trust boundaries to make the documentation easier to navigate.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,8 +1,3 @@
----
-title: CI/CD
-last_verified: 2026-09-09
----
-
 # CI/CD
 
 ## Overview
@@ -421,15 +416,3 @@ jobs:
 
 - [Testing](testing.md) - Testing utilities and patterns
 - [Configuration](configuration.md) - Project and build configuration
-
-## Changelog
-
-- **2026-09-09** — Added explicit type and LCOV checks, frozen dependency
-  installation, registry permissions, and deployment validation guidance.
-
-- **2026-09-05** — Tailwind build and dev permission profiles allow only the
-  `osRelease` system query needed by jiti's Windows terminal-color detection.
-  Reproduce CI builds without `NO_COLOR` or `TERM=dumb`, which bypass that
-  query.
-- **2026-09-05** — Documented platform coverage and production-build checks for
-  Windows CSS entry failures.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,3 @@
----
-title: Configuration
-last_verified: 2026-09-09
----
-
 # Configuration
 
 ## Project Configuration (deno.json)
@@ -392,8 +387,3 @@ To exclude build output from formatting and type checking:
 
 - [Styling](styling.md) - CSS and TailwindCSS integration
 - [Deployment](deployment.md) - Deploy to Deno Deploy, Docker, and more
-
-## Changelog
-
-- **2026-09-09** — Aligned React Router versions with the template and clarified
-  explicit environment loading and the limits of the public-variable allowlist.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,8 +1,3 @@
----
-title: Database
-last_verified: 2026-09-09
----
-
 # Database
 
 ## Overview
@@ -747,12 +742,3 @@ export async function action({ request }: RouteActionArgs) {
 
 - [Forms](forms.md) - Form handling with client and server actions
 - [Error Handling](error-handling.md) - Error boundaries and HttpError
-
-## Changelog
-
-- **2026-09-09** — Typed the transaction lookup and removed redundant comments
-  from the revised examples.
-
-- **2026-09-09** — Fixed the user-update transaction so unchanged emails retain
-  their index and changed emails preserve uniqueness under concurrent writes;
-  shared concurrent KV opens and documented handle cleanup.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,3 @@
----
-title: Deployment
-last_verified: 2026-09-09
----
-
 # Deployment
 
 ## Overview
@@ -389,9 +384,3 @@ applications
 - [CI/CD](ci-cd.md) - GitHub Actions workflows
 - [Logging](logging.md) - Logging and OpenTelemetry
 - [Configuration](configuration.md) - Project and build configuration
-
-## Changelog
-
-- **2026-09-09** — Corrected production packaging and cache semantics, added
-  long-running server and deployment recovery guidance, and replaced unverified
-  adapter recipes with runtime requirements.

--- a/docs/development-tools.md
+++ b/docs/development-tools.md
@@ -1,8 +1,3 @@
----
-title: Development Tools
-last_verified: 2026-09-09
----
-
 # Development Tools
 
 ## Development Server
@@ -332,8 +327,3 @@ JetBrains IDEs (WebStorm, IntelliJ IDEA) have built-in Deno support:
 
 - [Testing](testing.md) - Testing utilities and patterns
 - [Logging](logging.md) - Logging and OpenTelemetry
-
-## Changelog
-
-- **2026-09-09** — Clarified document reload behavior and kept debugger and task
-  examples on the template permission and environment profiles.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,8 +1,3 @@
----
-title: Error Handling
-last_verified: 2026-09-09
----
-
 # Error Handling
 
 ## Overview
@@ -476,15 +471,3 @@ export function ErrorBoundary(
 - [Logging](logging.md) - Logging and OpenTelemetry
 - [Testing](testing.md) - Testing utilities and patterns
 - [Middleware](middleware.md) - Server and client middleware
-
-## Changelog
-
-- **2026-09-09** — Clarified custom error preservation by response path and
-  replaced unsupported rich-type claims with the serialization contract.
-
-- **2026-09-09** — Documented production error sanitization and
-  ancestor-boundary rendering without denied loader data; completed imports in
-  revised examples.
-
-- **2026-09-09** — Corrected shared-layout lifetime and client serializer
-  registration; distinguished exposed error messages from private details.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,8 +1,3 @@
----
-title: Forms
-last_verified: 2026-09-09
----
-
 # Forms
 
 ## Overview
@@ -662,15 +657,3 @@ content type. The browser-supplied filename and MIME type are untrusted.
 - [Error Handling](error-handling.md) - Error boundaries and HttpError
 - [Database](database.md) - Deno KV and PostgreSQL
 - [Testing](testing.md) - Testing utilities and patterns
-
-## Changelog
-
-- **2026-09-09** — Corrected action-data serialization claims, including bigint
-  normalization and custom classes.
-
-- **2026-09-09** — Removed explanatory comments from the revised submission and
-  validation examples.
-
-- **2026-09-09** — Corrected navigation pending state, fetcher action targets
-  and POST submission; validated untrusted fields and uploads and derived
-  ownership from server context.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,3 @@
----
-title: Getting Started
-last_verified: 2026-09-09
----
-
 # Getting Started
 
 ## Prerequisites
@@ -371,8 +366,3 @@ deno task check
 - [Routing](routing.md) - File-based routing and data loading
 - [Middleware](middleware.md) - Server and client middleware
 - [Styling](styling.md) - CSS and TailwindCSS integration
-
-## Changelog
-
-- **2026-09-09** — Documented the Deno requirement for named permission sets and
-  aligned React Router with the tested template.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,8 +1,3 @@
----
-title: Introduction
-last_verified: 2026-09-09
----
-
 # Introduction
 
 ## What is Juniper?
@@ -166,8 +161,3 @@ Juniper may not be the best fit for:
 - [Routing](routing.md) - File-based routing and data loading
 - [Tutorials](tutorials/README.md) - Step-by-step guides for building
   applications
-
-## Changelog
-
-- **2026-09-09** — Explained document requests, hydration, lazy navigation, and
-  the server trust boundary; removed an unmaintained framework comparison.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,8 +1,3 @@
----
-title: Logging
-last_verified: 2026-09-09
----
-
 # Logging
 
 ## Overview
@@ -410,11 +405,3 @@ rm -rf docker/volumes/lgtm
 
 - [Error Handling](error-handling.md) - Error boundaries and HttpError
 - [Deployment](deployment.md) - Deploy to Deno Deploy, Docker, and more
-
-## Changelog
-
-- **2026-09-09** — Removed narrative comments from the revised metrics example.
-
-- **2026-09-09** — Made the KV tracing example concrete, corrected entry
-  handling, and removed personal data and unbounded request paths from telemetry
-  examples.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,8 +1,3 @@
----
-title: Metadata
-last_verified: 2026-09-09
----
-
 # Metadata
 
 ## React 19 Document Metadata
@@ -327,11 +322,3 @@ dynamic values. See React's
 - [Routing](routing.md) - File-based routing and data loading
 - [Styling](styling.md) - CSS and TailwindCSS integration
 - [Static Files](static-files.md) - Serving static assets
-
-## Changelog
-
-- **2026-09-09** — Replaced placeholder article content and removed redundant
-  comments from the revised metadata examples.
-
-- **2026-09-09** — Corrected title ownership and string children, typed route
-  examples, and escaped JSON-LD values embedded in HTML.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,8 +1,3 @@
----
-title: Middleware
-last_verified: 2026-09-09
----
-
 # Middleware
 
 ## Overview
@@ -464,12 +459,3 @@ for hydration must contain only data that client is allowed to receive.
 - [State Management](state-management.md) - Sharing data across your app
 - [Error Handling](error-handling.md) - Error boundaries and HttpError
 - [Logging](logging.md) - Logging and OpenTelemetry
-
-## Changelog
-
-- **2026-09-09** — Removed redundant comments from the revised authentication
-  and client middleware examples.
-
-- **2026-09-09** — Corrected the execution matrix and lazy middleware
-  limitation; made authorization checks explicit and separated client navigation
-  from server access control.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,8 +1,3 @@
----
-title: Routing
-last_verified: 2026-09-09
----
-
 # Routing
 
 ## File-Based Routing
@@ -943,15 +938,3 @@ function SearchFilters() {
 - [Forms](forms.md) - Form handling with client and server actions
 - [Error Handling](error-handling.md) - Error boundaries and HttpError
 - [State Management](state-management.md) - Sharing data across your app
-
-## Changelog
-
-- **2026-09-09** — Corrected default serialization claims and linked the
-  supported-value and custom-registration contract.
-
-- **2026-09-09** — Replaced the incorrect version-cookie refresh recipe with an
-  explicit document redirect; clarified blocking authentication and cleaned up
-  revised examples.
-
-- **2026-09-09** — Clarified universal loader execution, deferred redirect
-  limits, layout remounting, root pending feedback, and the beforeHydrate hook.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -1,8 +1,3 @@
----
-title: State Management
-last_verified: 2026-09-09
----
-
 # State Management
 
 ## Overview
@@ -879,13 +874,3 @@ disagree with SSR.
 - [Middleware](middleware.md) - Server and client middleware
 - [Routing](routing.md) - File-based routing and data loading
 - [Database](database.md) - Deno KV and PostgreSQL
-
-## Changelog
-
-- **2026-09-09** — Documented verified serialization behavior and URL
-  registration; corrected React Context SSR behavior and moved browser storage
-  reads after hydration.
-
-- **2026-09-09** — Fixed async loader examples and explained context
-  registration timing, public serialization, and revalidation versus cached
-  query data.

--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -1,8 +1,3 @@
----
-title: Static Files
-last_verified: 2026-09-09
----
-
 # Static Files
 
 ## Public Directory
@@ -281,8 +276,3 @@ export default app;
 - [Styling](styling.md) - CSS and TailwindCSS integration
 - [Configuration](configuration.md) - Project and build configuration
 - [Deployment](deployment.md) - Deploy to Deno Deploy, Docker, and more
-
-## Changelog
-
-- **2026-09-09** — Corrected automatic CSS inclusion and distinguished hashed
-  chunks from stable build entries when configuring long-lived caches.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,8 +1,3 @@
----
-title: Styling
-last_verified: 2026-09-09
----
-
 # Styling
 
 ## Overview
@@ -868,11 +863,3 @@ details on build artifact caching and how to customize it.
 
 - [Configuration](configuration.md) - Project and build configuration
 - [Metadata](metadata.md) - Page titles and meta tags
-
-## Changelog
-
-- **2026-09-09** — Removed redundant comments from revised stylesheet examples
-  while keeping resource paths explicit.
-
-- **2026-09-09** — Corrected React stylesheet precedence, documented generated
-  CSS-module mappings, and aligned the PostCSS plugin with the template.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,3 @@
----
-title: Testing
-last_verified: 2026-09-09
----
-
 # Testing
 
 Use component tests for UI behavior, `createRoutesStub` for Juniper's client
@@ -362,12 +357,3 @@ snapshot diff and keep behavioral assertions for important state changes.
 - [Forms](forms.md): route actions and fetchers.
 - [Error handling](error-handling.md): failure paths and serialization.
 - [CI/CD](ci-cd.md): run the same validation in automation.
-
-## Changelog
-
-- **2026-09-09** — Clarified that waitForFakeTime drains due work without
-  advancing elapsed fake time.
-
-- **2026-09-09** — Replaced action tests that never submitted with complete
-  interaction tests, documented adapter boundaries and environment isolation,
-  and corrected task invocation, fixture cleanup, and snapshot arguments.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,8 +1,3 @@
----
-title: Tutorials
-last_verified: 2026-09-09
----
-
 # Tutorials
 
 This section provides hands-on tutorials for learning Juniper. Each tutorial
@@ -64,8 +59,3 @@ root; in the copied tutorial project, run `deno task test`. See
 - [Routing](../routing.md) - File-based routing and data loading
 - [Forms](../forms.md) - Form handling and actions
 - [Middleware](../middleware.md) - Adding authentication and other middleware
-
-## Changelog
-
-- **2026-09-09** — Clarified public mutation endpoints and the tutorial
-  validation scope, plus standalone versus repository test commands.

--- a/docs/tutorials/blog.md
+++ b/docs/tutorials/blog.md
@@ -1,8 +1,3 @@
----
-title: Building a Blog Application
-last_verified: 2026-09-09
----
-
 # Building a Blog Application
 
 This tutorial walks you through building a full-featured blog application with
@@ -1023,8 +1018,3 @@ Additional enhancements:
 - [Forms](../forms.md) - Form handling and validation
 - [Error Handling](../error-handling.md) - Error boundaries and HttpError
 - [Deployment](../deployment.md) - Deploy your application
-
-## Changelog
-
-- **2026-09-09** — Updated the Deno prerequisite and fixed dynamic page titles
-  to render one string.


### PR DESCRIPTION
## Summary

Juniper's published guides should be plain Markdown for package users. Remove the internal frontmatter blocks, verification dates, and per-document changelog sections introduced during the documentation review.

## Changes

- Remove this bookkeeping from all 20 files in docs/, including the guide index and tutorials.
- Preserve the guides' content and links, public JSDoc, and the package-level release changelog.
- Publish the correction as a patch so the cleaned guides reach JSR as well as GitHub.

The parent Udibo repository is updating its CLAUDE.md to keep internal documentation rules separate from external package documentation across all packages.

## Testing

- Full Juniper checks, including public JSDoc and compiled examples.
- Juniper suite: 33 groups / 382 steps passed.
- Confirmed that every guide starts with its Markdown title and no guide retains frontmatter or a Changelog section.

## Closes

Nothing.
