### PR TITLE
fix: revalidate stable-named build assets

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -288,6 +288,10 @@ Juniper automatically applies cache headers to build artifacts:
   Uses `no-cache` with ETag validation. Caches may store it but must validate it
   before reuse, so HTML, JavaScript, and styles stay consistent across deploys.
 
+`private` also means a shared cache may not store those files at all, so entry
+points such as `main.css` are served from the origin rather than a CDN edge.
+Each request is a conditional one that usually answers `304 Not Modified`.
+
 CDNs can override these headers. Verify them on the public custom domain, not
 only on a preview hostname.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -282,10 +282,14 @@ const cacheMaxAge = isProduction() ? 3600 : 0;
 
 Juniper automatically applies cache headers to build artifacts:
 
-- **`/build/main.js`**: Uses `no-cache` with ETag validation. Caches may store
-  it but must validate it before reuse.
-- **Other `/build/*` files**: Cached for 4 hours. Lazy JavaScript chunks have
-  content hashes; explicit entries such as `main.css` can have stable names.
+- **Fingerprinted `/build/*` files** (`name-XXXXXXXX.ext`): Cached for 4 hours.
+  The hash in the filename changes with the content.
+- **Every other `/build/*` file** (`main.js`, `main.css`, custom entry points):
+  Uses `no-cache` with ETag validation. Caches may store it but must validate it
+  before reuse, so HTML, JavaScript, and styles stay consistent across deploys.
+
+CDNs can override these headers. Verify them on the public custom domain, not
+only on a preview hostname.
 
 You can override these defaults in your route handlers. See
 [Static Files - Cache Headers](static-files.md#cache-headers) for details on

--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -158,32 +158,35 @@ ls -la public/build/
 
 ### Default Build Artifact Caching
 
-Juniper automatically applies cache headers to build artifacts in `/build/`:
+Juniper automatically applies cache headers to build artifacts in `/build/`
+based on whether the filename carries a content hash:
 
-| File             | Cache-Control                                   | Reason                                                    |
-| ---------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/build/main.js` | `private, no-cache, must-revalidate, max-age=0` | Main entry point changes on each build, uses ETag         |
-| Other `/build/*` | `public, max-age=14400` (4 hours)               | Default for the build directory; not every file is hashed |
+| File                                          | Cache-Control                                   | Reason                                                             |
+| --------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
+| Fingerprinted (`name-XXXXXXXX.ext`)           | `public, max-age=14400` (4 hours)               | The hash in the filename changes whenever the content changes      |
+| Everything else (`main.js`, `main.css`, etc.) | `private, no-cache, must-revalidate, max-age=0` | Stable URL, so every request revalidates against the current build |
 
-The `main.js` bundle uses `no-cache` with ETag validation because:
+Fingerprinted files are the lazy chunks and any esbuild output whose name ends
+in a dash followed by an eight-character hash, including their source maps.
+Everything else is treated as a stable URL: `main.js`, every entry point you
+pass to the `Builder` (such as `main.css` or `styles/theme.css`), and their
+source maps.
 
-- It doesn't have a content hash in its filename
-- CDNs and proxies should not cache it (hence `private`)
-- Browsers can still use their cache if the ETag matches, avoiding re-downloads
-  when unchanged
+Stable URLs use `no-cache` with ETag validation because:
 
-Other build files like `chunk-[hash].js` can be cached longer because the hash
-in the filename changes when content changes.
-
-CSS and other explicitly named entry points may keep a stable filename. Give
-those files a revalidation policy instead of treating the whole build directory
-as immutable.
+- Their filenames do not change between builds, so a long lifetime would let a
+  browser pair new HTML and JavaScript with a stylesheet from a previous
+  deployment
+- CDNs and proxies should not cache them (hence `private`)
+- Browsers still reuse their cached copy when the ETag matches, so revalidation
+  costs a conditional request that returns `304 Not Modified` rather than a
+  re-download
 
 ### Overriding Default Cache Headers
 
 The framework sets cache headers _before_ your route handlers run, so you can
 override them with your own middleware. For example, to extend caching for
-chunked build files (which have content hashes in their filenames):
+fingerprinted build files:
 
 ```typescript
 // routes/main.ts
@@ -193,8 +196,8 @@ const app = new Hono();
 
 app.use("/build/*", async (c, next) => {
   const pathname = new URL(c.req.url).pathname;
-  if (/\/[^/]+-[A-Z0-9]{8}\.js$/.test(pathname)) {
-    c.header("Cache-Control", "public, max-age=31536000");
+  if (/-[A-Z0-9]{8}\.[a-z0-9]+$/.test(pathname)) {
+    c.header("Cache-Control", "public, max-age=31536000, immutable");
   }
   await next();
 });
@@ -207,33 +210,28 @@ export default app;
 headers after `next()`, your middleware has the final say and routes cannot
 customize the caching behavior for specific responses.
 
-### Adding ETag Validation for CSS Entry Points
+### Migrating Previously Cached Stable URLs
 
-If you have a CSS entry point (like `main.css` from TailwindCSS or Sass), you
-may want to apply the same caching strategy as `main.js` - preventing CDN
-caching while allowing efficient browser cache validation with ETags:
+Changing response headers does not invalidate a copy a browser has already
+stored as fresh. A visitor who cached `/build/main.css` under an earlier
+four-hour policy keeps using it until that lifetime runs out, no matter what the
+origin sends now. To force the switch once, change the URL the layout links to
+so the stale entry is never looked up again:
 
-```typescript
-// routes/main.ts
-import { Hono } from "hono";
-import { etag } from "hono/etag";
-
-const app = new Hono();
-
-// Apply no-cache with ETag for main.css (same strategy as main.js)
-app.use("/build/main.css", etag(), async (c, next) => {
-  c.header("Cache-Control", "private, no-cache, must-revalidate, max-age=0");
-  await next();
-});
-
-export default app;
+```tsx
+// routes/main.tsx
+<link rel="stylesheet" href="/build/main.css?v=2" precedence="default" />;
 ```
 
-This is useful for CSS entry points because:
+Any change works: a query string, a renamed entry point, or a versioned path.
+The new URL is served with the revalidation policy, so you can drop the suffix
+in a later release once the old lifetime has expired.
 
-- The filename doesn't include a content hash
-- Users get the latest styles immediately after deployment
-- ETags prevent unnecessary re-downloads when the file hasn't changed
+CDNs can override origin headers. Cloudflare's
+[Browser Cache TTL](https://developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/set-browser-ttl/)
+setting, for example, can replace `Cache-Control` before the response reaches
+the browser. Verify the headers on the public custom domain rather than only on
+localhost or a preview hostname.
 
 ### Custom Static Asset Caching
 
@@ -258,14 +256,14 @@ export default app;
 
 **Cache strategies:**
 
-| Asset Type                | Cache-Control                               | Reason                          |
-| ------------------------- | ------------------------------------------- | ------------------------------- |
-| `main.js` (framework)     | `private, no-cache, must-revalidate` + ETag | No hash, needs revalidation     |
-| Chunked JS (`chunk-*.js`) | `public, max-age=14400`                     | Content hash in filename        |
-| CSS entry points          | Consider `no-cache` + ETag (see above)      | No hash, may want revalidation  |
-| Images/fonts              | `max-age=86400`                             | May change, cache for 1 day     |
-| HTML                      | `no-cache`                                  | Always fetch latest             |
-| API responses             | Varies                                      | Depends on data freshness needs |
+| Asset Type                          | Cache-Control                               | Reason                          |
+| ----------------------------------- | ------------------------------------------- | ------------------------------- |
+| `main.js` (framework)               | `private, no-cache, must-revalidate` + ETag | No hash, needs revalidation     |
+| CSS and other stable entry points   | `private, no-cache, must-revalidate` + ETag | No hash, needs revalidation     |
+| Fingerprinted output (`*-XXXXXXXX`) | `public, max-age=14400`                     | Content hash in filename        |
+| Images/fonts                        | `max-age=86400`                             | May change, cache for 1 day     |
+| HTML                                | `no-cache`                                  | Always fetch latest             |
+| API responses                       | Varies                                      | Depends on data freshness needs |
 
 ## Next Steps
 

--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -172,6 +172,12 @@ Everything else is treated as a stable URL: `main.js`, every entry point you
 pass to the `Builder` (such as `main.css` or `styles/theme.css`), and their
 source maps.
 
+The rule is the filename, so do not name an entry point or a file you place in
+`public/build` `<stem>-XXXXXXXX.<ext>` where the suffix is eight uppercase
+letters or digits — `sw-REGISTER.js` and `Inter-VARIABLE.woff2` both read as
+fingerprinted and would be cached for four hours under a URL that never changes.
+Any other shape, `theme-dark.css` included, revalidates.
+
 Stable URLs use `no-cache` with ETag validation because:
 
 - Their filenames do not change between builds, so a long lifetime would let a
@@ -196,7 +202,7 @@ const app = new Hono();
 
 app.use("/build/*", async (c, next) => {
   const pathname = new URL(c.req.url).pathname;
-  if (/-[A-Z0-9]{8}\.[a-z0-9]+$/.test(pathname)) {
+  if (/-[A-Z0-9]{8}\.[A-Za-z0-9]+(?:\.map)?$/.test(pathname)) {
     c.header("Cache-Control", "public, max-age=31536000, immutable");
   }
   await next();

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -825,35 +825,16 @@ To prevent FOUC during SSR:
 
 ## Caching Considerations
 
-When using CSS entry points like `main.css` (from TailwindCSS, Sass, or other
-preprocessors), the built file at `/build/main.css` doesn't include a content
-hash in its filename. This means CDNs and browsers may serve stale styles after
-deployments.
+The built file at `/build/main.css` keeps a stable filename, so Juniper serves
+it with `private, no-cache, must-revalidate, max-age=0` and an ETag. Browsers
+revalidate it on every page load and get `304 Not Modified` when nothing
+changed, so styles update immediately after a deployment without repeated
+downloads. Custom CSS entry points get the same treatment.
 
-To ensure users always get the latest styles while still benefiting from browser
-caching, consider adding ETag validation for your CSS entry points:
-
-```typescript
-// routes/main.ts
-import { Hono } from "hono";
-import { etag } from "hono/etag";
-
-const app = new Hono();
-
-// Require revalidation for main.css (same strategy as main.js)
-app.use("/build/main.css", etag(), async (c, next) => {
-  c.header("Cache-Control", "private, no-cache, must-revalidate, max-age=0");
-  await next();
-});
-
-export default app;
-```
-
-This prevents CDNs from caching your stylesheet while allowing browsers to use
-ETags for efficient cache validation.
-
-See [Static Files - Cache Headers](static-files.md#cache-headers) for more
-details on build artifact caching and how to customize it.
+If an earlier release served the stylesheet with a long lifetime, visitors keep
+their cached copy until it expires. See
+[Migrating Previously Cached Stable URLs](static-files.md#migrating-previously-cached-stable-urls)
+for the one-time URL change that clears it.
 
 ## Next Steps
 

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -1346,6 +1346,32 @@ describe("build artifact cache control", () => {
     }
   });
 
+  it("should revalidate a hyphenated name that is not an esbuild hash", async () => {
+    const { dir, server } = await makeBuild({
+      "theme-dark.css": ".dark { color: white; }",
+      "main-ABC123.css": ".short { color: gray; }",
+      "main-abcd2345.css": ".lower { color: black; }",
+      "vendor-ABCD2345EF.js": "export const vendor = 1;",
+    });
+    try {
+      for (
+        const pathname of [
+          "/build/theme-dark.css",
+          "/build/main-ABC123.css",
+          "/build/main-abcd2345.css",
+          "/build/vendor-ABCD2345EF.js",
+        ]
+      ) {
+        const res = await headersFor(server, pathname);
+        assertEquals(res.status, 200, pathname);
+        assertEquals(res.cacheControl, revalidate, pathname);
+        assertExists(res.etag, pathname);
+      }
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
   it("should set long cache headers for fingerprinted /build/* files", async () => {
     const { dir, server } = await makeBuild({
       "chunk-ABC123XY.js": "export const x = 1;",
@@ -1395,6 +1421,16 @@ describe("build artifact cache control", () => {
       });
       assertEquals(changed.status, 200);
       assertEquals(await changed.text(), "body { color: red; }");
+
+      await Deno.writeTextFile(
+        path.join(dir, "public", "build", "main.css"),
+        "body { color: blue; }",
+      );
+      const rebuilt = await server.request("http://localhost/build/main.css", {
+        headers: { "If-None-Match": etag },
+      });
+      assertEquals(rebuilt.status, 200);
+      assertEquals(await rebuilt.text(), "body { color: blue; }");
     } finally {
       await Deno.remove(dir, { recursive: true });
     }

--- a/src/server.test.tsx
+++ b/src/server.test.tsx
@@ -1257,63 +1257,146 @@ describe("redirect header preservation", () => {
 });
 
 describe("build artifact cache control", () => {
+  const revalidate = "private, no-cache, must-revalidate, max-age=0";
+  const longLived = "public, max-age=14400";
+
+  async function makeBuild(
+    files: Record<string, string>,
+  ): Promise<{ dir: string; server: ReturnType<typeof createServer> }> {
+    const dir = await Deno.makeTempDir();
+    for (const [name, contents] of Object.entries(files)) {
+      const file = path.join(dir, "public", "build", name);
+      await Deno.mkdir(path.dirname(file), { recursive: true });
+      await Deno.writeTextFile(file, contents);
+    }
+    const client = new Client({
+      path: "/",
+      main: { default: () => <div>Home</div> },
+    });
+    const server = createServer(`file://${dir}/server.ts`, client, {
+      path: "/",
+    });
+    return { dir, server };
+  }
+
+  async function headersFor(
+    server: ReturnType<typeof createServer>,
+    pathname: string,
+  ): Promise<
+    { status: number; cacheControl: string | null; etag: string | null }
+  > {
+    const res = await server.request(`http://localhost${pathname}`);
+    await res.body?.cancel();
+    return {
+      status: res.status,
+      cacheControl: res.headers.get("Cache-Control"),
+      etag: res.headers.get("ETag"),
+    };
+  }
+
   it("should set no-cache headers with etag for /build/main.js", async () => {
-    const tempDir = await Deno.makeTempDir();
+    const { dir, server } = await makeBuild({
+      "main.js": "console.log('test');",
+    });
     try {
-      const buildDir = `${tempDir}/public/build`;
-      await Deno.mkdir(buildDir, { recursive: true });
-      await Deno.writeTextFile(`${buildDir}/main.js`, "console.log('test');");
-
-      const client = new Client({
-        path: "/",
-        main: { default: () => <div>Home</div> },
-      });
-
-      const server = createServer(`file://${tempDir}/server.ts`, client, {
-        path: "/",
-      });
-
-      const res = await server.request("http://localhost/build/main.js");
+      const res = await headersFor(server, "/build/main.js");
       assertEquals(res.status, 200);
-      assertEquals(
-        res.headers.get("Cache-Control"),
-        "private, no-cache, must-revalidate, max-age=0",
-      );
-      assertExists(res.headers.get("ETag"));
-      await res.body?.cancel();
+      assertEquals(res.cacheControl, revalidate);
+      assertExists(res.etag);
     } finally {
-      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(dir, { recursive: true });
     }
   });
 
-  it("should set long cache headers for other /build/* files", async () => {
-    const tempDir = await Deno.makeTempDir();
+  it("should revalidate stable-named CSS entry points like /build/main.css", async () => {
+    const { dir, server } = await makeBuild({
+      "main.css": "body { color: red; }",
+    });
     try {
-      const buildDir = `${tempDir}/public/build`;
-      await Deno.mkdir(buildDir, { recursive: true });
-      await Deno.writeTextFile(
-        `${buildDir}/chunk-abc123.js`,
-        "export const x = 1;",
-      );
-
-      const client = new Client({
-        path: "/",
-        main: { default: () => <div>Home</div> },
-      });
-
-      const server = createServer(`file://${tempDir}/server.ts`, client, {
-        path: "/",
-      });
-
-      const res = await server.request(
-        "http://localhost/build/chunk-abc123.js",
-      );
+      const res = await headersFor(server, "/build/main.css");
       assertEquals(res.status, 200);
-      assertEquals(res.headers.get("Cache-Control"), "public, max-age=14400");
-      assertEquals(res.headers.get("ETag"), null);
-      await res.body?.cancel();
+      assertEquals(res.cacheControl, revalidate);
+      assertExists(res.etag);
     } finally {
-      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("should revalidate custom entry points that keep their filename", async () => {
+    const { dir, server } = await makeBuild({
+      "styles/theme.css": ".theme { color: blue; }",
+      "workers/sw.js": "self.addEventListener('fetch', () => {});",
+      "main.js.map": "{}",
+    });
+    try {
+      for (
+        const pathname of [
+          "/build/styles/theme.css",
+          "/build/workers/sw.js",
+          "/build/main.js.map",
+        ]
+      ) {
+        const res = await headersFor(server, pathname);
+        assertEquals(res.status, 200, pathname);
+        assertEquals(res.cacheControl, revalidate, pathname);
+        assertExists(res.etag, pathname);
+      }
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("should set long cache headers for fingerprinted /build/* files", async () => {
+    const { dir, server } = await makeBuild({
+      "chunk-ABC123XY.js": "export const x = 1;",
+      "chunk-ABC123XY.js.map": "{}",
+      "main-2E3V2KW6.css": ".hashed { color: green; }",
+      "routes/about-U7H2PI3A.js": "export const about = true;",
+    });
+    try {
+      for (
+        const pathname of [
+          "/build/chunk-ABC123XY.js",
+          "/build/chunk-ABC123XY.js.map",
+          "/build/main-2E3V2KW6.css",
+          "/build/routes/about-U7H2PI3A.js",
+        ]
+      ) {
+        const res = await headersFor(server, pathname);
+        assertEquals(res.status, 200, pathname);
+        assertEquals(res.cacheControl, longLived, pathname);
+        assertEquals(res.etag, null, pathname);
+      }
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("should answer a matching If-None-Match for a stable asset with 304", async () => {
+    const { dir, server } = await makeBuild({
+      "main.css": "body { color: red; }",
+    });
+    try {
+      const first = await server.request("http://localhost/build/main.css");
+      const etag = first.headers.get("ETag");
+      await first.body?.cancel();
+      assertExists(etag);
+
+      const cached = await server.request("http://localhost/build/main.css", {
+        headers: { "If-None-Match": etag },
+      });
+      assertEquals(cached.status, 304);
+      assertEquals(cached.headers.get("Cache-Control"), revalidate);
+      assertEquals(cached.headers.get("ETag"), etag);
+      await cached.body?.cancel();
+
+      const changed = await server.request("http://localhost/build/main.css", {
+        headers: { "If-None-Match": '"stale"' },
+      });
+      assertEquals(changed.status, 200);
+      assertEquals(await changed.text(), "body { color: red; }");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
     }
   });
 });

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -34,6 +34,12 @@ export type {
   ServerRouteModule,
 } from "./_server.tsx";
 
+const FINGERPRINTED_BUILD_ASSET = /-[A-Z0-9]{8}\.[A-Za-z0-9]+(?:\.map)?$/;
+
+function isFingerprintedBuildAsset(pathname: string): boolean {
+  return FINGERPRINTED_BUILD_ASSET.test(pathname);
+}
+
 function varyByRoute(headers: Headers): void {
   const names = new Set(
     (headers.get("Vary") ?? "").split(",").map((name) =>
@@ -115,16 +121,15 @@ export function createServer<
 
   appWrapper.use(trimTrailingSlash());
 
-  appWrapper.use("/build/main.js", etag(), async (c, next) => {
-    c.header("Cache-Control", "private, no-cache, must-revalidate, max-age=0");
-    await next();
-  });
-  appWrapper.use("/build/*", async (c, next) => {
+  const revalidate = etag();
+  appWrapper.use("/build/*", (c, next) => {
     const pathname = new URL(c.req.url).pathname;
-    if (pathname !== "/build/main.js") {
+    if (isFingerprintedBuildAsset(pathname)) {
       c.header("Cache-Control", "public, max-age=14400");
+      return next();
     }
-    await next();
+    c.header("Cache-Control", "private, no-cache, must-revalidate, max-age=0");
+    return revalidate(c, next);
   });
 
   appWrapper.onError((cause) => {


### PR DESCRIPTION
## Summary

Juniper served every `/build/*` file other than `main.js` with `public, max-age=14400`, including CSS entry points whose filenames never change. After a deployment a browser could pair new HTML and JavaScript with a stylesheet from the previous build for up to four hours. The cache policy is now keyed on whether the filename is fingerprinted: esbuild's `name-XXXXXXXX.ext` outputs (and their source maps) keep the four-hour lifetime, and every other build asset gets the same `private, no-cache, must-revalidate, max-age=0` plus ETag treatment `main.js` already had.

## Changes

- `src/server.tsx`: one `/build/*` middleware that applies long-lived caching only to fingerprinted names and ETag revalidation to everything else (`main.js`, `main.css`, custom entry points such as `styles/theme.css` or `workers/sw.js`, and their source maps).
- `src/server.test.tsx`: coverage for `main.css`, nested stable entry points and source maps, fingerprinted JS/CSS/map/route chunks keeping `public, max-age=14400` with no ETag, and a conditional request round trip (`If-None-Match` → 304 with headers retained, mismatch → 200 with body).
- `docs/static-files.md`, `docs/styling.md`, `docs/deployment.md`: state the actual defaults, drop the per-app ETag middleware recipe the framework now covers, add a migration section for URLs browsers already cached under the old policy (change the asset URL once), and note that CDN settings can override origin headers so verification belongs on the public custom domain.

## Testing

- `deno task check` and `deno task test --parallel --reporter=dot` green (33 files, 385 steps).
- Regression proof: with the original middleware restored, the three new stable-asset tests fail at the `Cache-Control` and `ETag` assertions; the fingerprinted-asset test stays green on both.

## Closes

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
