### PR TITLE
chore: exempt @udibo packages from the minimum dependency age

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,8 @@
 {
-  "minimumDependencyAge": "P3D",
+  "minimumDependencyAge": {
+    "age": "P3D",
+    "exclude": ["jsr:@udibo/*"]
+  },
   "workspace": [
     "./src",
     "./example",


### PR DESCRIPTION
## Summary

`minimumDependencyAge` now reads `{ "age": "P3D", "exclude": ["jsr:@udibo/*"] }`. We publish the `@udibo` packages ourselves and adopt each release as soon as it ships, so the three-day supply-chain gate applies to third-party packages only.

The previous workaround, `deno install --min-dep-age=0`, lifts the gate for every constraint resolved in that run: adopting juniper 0.11.5 downstream that way also pulled a two-day-old react 19.3.0.

Config only — no published file changes, so `chore:` (no release).

## Testing

- `deno install --frozen`: lock unchanged.
- `deno task check`: pass.
- `test`, `test:example`, `test:minimal`, `test:tailwindcss`, `test:tanstack`, `test:blog`: pass. Postgres template left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)