### PR TITLE
fix: preserve own keys through serialization

### DIFF
--- a/src/_serialization.test.ts
+++ b/src/_serialization.test.ts
@@ -820,3 +820,101 @@ describe("Serialization Module", () => {
     });
   });
 });
+
+describe("decoding an own __proto__ key where assignment sets the prototype", () => {
+  const browserDecodeScript = `
+const {
+  createStreamingLoaderData,
+  deserializeHydrationData,
+  deserializeLoaderData,
+  deserializeStreamingLoaderData,
+  serializeHydrationData,
+  serializeLoaderData,
+} = await import(${
+    JSON.stringify(new URL("./_serialization.ts", import.meta.url).href)
+  });
+
+const untrusted = () =>
+  JSON.parse('{"__proto__":{"isAdmin":true},"name":"guest"}');
+
+const hydration = await serializeHydrationData({
+  matches: [{ id: "route" }],
+  loaderData: { route: untrusted() },
+});
+const loaderBytes = await serializeLoaderData(untrusted());
+const streamBytes = new Uint8Array(
+  await new Response(
+    createStreamingLoaderData({
+      prefs: untrusted(),
+      later: Promise.resolve(untrusted()),
+    }),
+  ).arrayBuffer(),
+);
+
+Object.defineProperty(Object.prototype, "__proto__", {
+  get() {
+    return Object.getPrototypeOf(this);
+  },
+  set(prototype) {
+    Object.setPrototypeOf(this, prototype);
+  },
+  configurable: true,
+});
+const probe = {};
+probe["__proto__"] = { viaAccessor: true };
+
+const report = (value) => ({
+  ownKeys: Object.keys(value),
+  hasOwnProto: Object.hasOwn(value, "__proto__"),
+  ownProtoValue: Object.getOwnPropertyDescriptor(value, "__proto__")?.value,
+  protoIsObjectPrototype: Object.getPrototypeOf(value) === Object.prototype,
+  isAdmin: "isAdmin" in value,
+});
+
+const streamed = await deserializeStreamingLoaderData(new Response(streamBytes));
+console.log(JSON.stringify({
+  accessorSetsPrototype: probe.viaAccessor === true &&
+    !Object.hasOwn(probe, "__proto__"),
+  "page load": report(deserializeHydrationData(hydration).loaderData.route),
+  "data request": report(deserializeLoaderData(loaderBytes)),
+  "streamed data": report(streamed.prefs),
+  "deferred data": report(await streamed.later),
+}));
+`;
+
+  async function decodeInBrowserLikeRuntime(): Promise<
+    Record<string, unknown>
+  > {
+    const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", browserDecodeScript],
+      cwd: new URL(".", import.meta.url),
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const decoder = new TextDecoder();
+    assertEquals(code, 0, decoder.decode(stderr));
+    return JSON.parse(decoder.decode(stdout));
+  }
+
+  it("keeps the key as an own property on every decode path", async () => {
+    const { accessorSetsPrototype, ...paths } =
+      await decodeInBrowserLikeRuntime();
+    assert(
+      accessorSetsPrototype,
+      "the child must assign __proto__ through the accessor, as browsers do",
+    );
+    const ownProtoKept = {
+      ownKeys: ["__proto__", "name"],
+      hasOwnProto: true,
+      ownProtoValue: { isAdmin: true },
+      protoIsObjectPrototype: true,
+      isAdmin: false,
+    };
+    assertEquals(paths, {
+      "page load": ownProtoKept,
+      "data request": ownProtoKept,
+      "streamed data": ownProtoKept,
+      "deferred data": ownProtoKept,
+    });
+  });
+});

--- a/src/_serialization.test.ts
+++ b/src/_serialization.test.ts
@@ -837,6 +837,22 @@ const {
 const untrusted = () =>
   JSON.parse('{"__proto__":{"isAdmin":true},"name":"guest"}');
 
+function installBrowserAccessor() {
+  Object.defineProperty(Object.prototype, "__proto__", {
+    get() {
+      return Object.getPrototypeOf(this);
+    },
+    set(prototype) {
+      Object.setPrototypeOf(this, prototype);
+    },
+    configurable: true,
+  });
+}
+
+if (Deno.args.includes("--encode-with-accessor")) {
+  installBrowserAccessor();
+}
+
 const hydration = await serializeHydrationData({
   matches: [{ id: "route" }],
   loaderData: { route: untrusted() },
@@ -851,15 +867,7 @@ const streamBytes = new Uint8Array(
   ).arrayBuffer(),
 );
 
-Object.defineProperty(Object.prototype, "__proto__", {
-  get() {
-    return Object.getPrototypeOf(this);
-  },
-  set(prototype) {
-    Object.setPrototypeOf(this, prototype);
-  },
-  configurable: true,
-});
+installBrowserAccessor();
 const probe = {};
 probe["__proto__"] = { viaAccessor: true };
 
@@ -867,26 +875,38 @@ const report = (value) => ({
   ownKeys: Object.keys(value),
   hasOwnProto: Object.hasOwn(value, "__proto__"),
   ownProtoValue: Object.getOwnPropertyDescriptor(value, "__proto__")?.value,
+  ownProtoWritable: Object.getOwnPropertyDescriptor(value, "__proto__")?.writable,
+  ownProtoConfigurable: Object.getOwnPropertyDescriptor(value, "__proto__")?.configurable,
   protoIsObjectPrototype: Object.getPrototypeOf(value) === Object.prototype,
   isAdmin: "isAdmin" in value,
 });
 
 const streamed = await deserializeStreamingLoaderData(new Response(streamBytes));
-console.log(JSON.stringify({
-  accessorSetsPrototype: probe.viaAccessor === true &&
-    !Object.hasOwn(probe, "__proto__"),
+const paths = {
   "page load": report(deserializeHydrationData(hydration).loaderData.route),
   "data request": report(deserializeLoaderData(loaderBytes)),
   "streamed data": report(streamed.prefs),
   "deferred data": report(await streamed.later),
+};
+console.log(JSON.stringify({
+  accessorSetsPrototype: probe.viaAccessor === true &&
+    !Object.hasOwn(probe, "__proto__"),
+  objectPrototypeUnaffected: ({}).isAdmin === undefined && !("isAdmin" in {}),
+  paths,
 }));
 `;
 
-  async function decodeInBrowserLikeRuntime(): Promise<
+  async function decodeInBrowserLikeRuntime(
+    encodeWithAccessor: boolean,
+  ): Promise<
     Record<string, unknown>
   > {
     const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
-      args: ["eval", browserDecodeScript],
+      args: [
+        "eval",
+        browserDecodeScript,
+        ...(encodeWithAccessor ? ["--encode-with-accessor"] : []),
+      ],
       cwd: new URL(".", import.meta.url),
       stdout: "piped",
       stderr: "piped",
@@ -896,25 +916,38 @@ console.log(JSON.stringify({
     return JSON.parse(decoder.decode(stdout));
   }
 
-  it("keeps the key as an own property on every decode path", async () => {
-    const { accessorSetsPrototype, ...paths } =
-      await decodeInBrowserLikeRuntime();
-    assert(
-      accessorSetsPrototype,
-      "the child must assign __proto__ through the accessor, as browsers do",
+  for (const encodeWithAccessor of [false, true]) {
+    it(
+      `keeps the key as an own property on every decode path (${
+        encodeWithAccessor ? "encode with accessor" : "decode with accessor"
+      })`,
+      async () => {
+        const { accessorSetsPrototype, objectPrototypeUnaffected, paths } =
+          await decodeInBrowserLikeRuntime(encodeWithAccessor);
+        assert(
+          accessorSetsPrototype,
+          "the child must assign __proto__ through the accessor, as browsers do",
+        );
+        assert(
+          objectPrototypeUnaffected,
+          "Object.prototype must remain unaffected",
+        );
+        const ownProtoKept = {
+          ownKeys: ["__proto__", "name"],
+          hasOwnProto: true,
+          ownProtoValue: { isAdmin: true },
+          ownProtoWritable: true,
+          ownProtoConfigurable: true,
+          protoIsObjectPrototype: true,
+          isAdmin: false,
+        };
+        assertEquals(paths, {
+          "page load": ownProtoKept,
+          "data request": ownProtoKept,
+          "streamed data": ownProtoKept,
+          "deferred data": ownProtoKept,
+        });
+      },
     );
-    const ownProtoKept = {
-      ownKeys: ["__proto__", "name"],
-      hasOwnProto: true,
-      ownProtoValue: { isAdmin: true },
-      protoIsObjectPrototype: true,
-      isAdmin: false,
-    };
-    assertEquals(paths, {
-      "page load": ownProtoKept,
-      "data request": ownProtoKept,
-      "streamed data": ownProtoKept,
-      "deferred data": ownProtoKept,
-    });
-  });
+  }
 });

--- a/src/_serialization.ts
+++ b/src/_serialization.ts
@@ -294,7 +294,7 @@ async function processValue(value: unknown): Promise<unknown> {
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = await processValue(val);
+      defineOwnValue(result, key, await processValue(val));
     }
     return result;
   }
@@ -477,10 +477,10 @@ function processValueForStreaming(
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = processValueForStreaming(
-        val,
-        pendingPromises,
-        `${idPrefix}${key}_`,
+      defineOwnValue(
+        result,
+        key,
+        processValueForStreaming(val, pendingPromises, `${idPrefix}${key}_`),
       );
     }
     return result;

--- a/src/_serialization.ts
+++ b/src/_serialization.ts
@@ -302,6 +302,19 @@ async function processValue(value: unknown): Promise<unknown> {
   return value;
 }
 
+function defineOwnValue(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
 function restoreValue(value: unknown): unknown {
   if (value === null || value === undefined) {
     return value;
@@ -351,7 +364,7 @@ function restoreValue(value: unknown): unknown {
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = restoreValue(val);
+      defineOwnValue(result, key, restoreValue(val));
     }
     return result;
   }
@@ -627,7 +640,11 @@ function restoreValueWithPendingPromises(
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = restoreValueWithPendingPromises(val, promiseResolvers);
+      defineOwnValue(
+        result,
+        key,
+        restoreValueWithPendingPromises(val, promiseResolvers),
+      );
     }
     return result;
   }


### PR DESCRIPTION
## Summary

Preserve untrusted own `__proto__` keys throughout Juniper serialization. Browser-style assignment previously substituted the object's prototype in the decoders; the same assignment in the preprocessing functions could drop the key before encoding. All four object-copy functions now use `defineOwnValue`.

## Changes

- Keep commit 92abe27's decoder fix and extend it to `processValue` and `processValueForStreaming`.
- Exercise hydration, settled data requests, stream initial data, and deferred stream values with the browser accessor installed during decoding, and during both encoding and decoding.
- Assert the own key, original value, writable/configurable/enumerable behavior, unchanged prototype, no inherited `isAdmin`, and unaffected `Object.prototype`. The accessor runs only in a child process; sanitizer settings are unchanged.

## Testing

- Red before the encoder fix: `deno task test --filter "decoding an own __proto__" _serialization.test.ts` failed at `assertEquals(paths, ...)` in the encode-with-accessor case. All four paths had `hasOwnProto: false` and `ownKeys: ["name"]`.
- Green after the fix: the same command passed both accessor modes across all four paths.
- Five focused mutations independently replaced `defineOwnValue` with assignment in the helper, `processValue`, `processValueForStreaming`, `restoreValue`, and `restoreValueWithPendingPromises`. Every run exited 1 at `AssertionError: Values are not equal.` Encoder mutations lost the own key; decoder mutations also produced `protoIsObjectPrototype: false` and inherited `isAdmin: true`. Restored source passes the full suite.
- `deno task check`: passes, including doc-lint's nine entrypoints and their JSDoc examples.
- `deno task test --parallel --reporter=dot`: 34 passed (388 steps), zero failures. The sandboxed run could not read esbuild temporary projects; the host run passed without code or sanitizer changes.
- Raw `deno doc --lint` over all nine export-map entrypoints exits 1 with 25 existing diagnostics, identical on main and this branch. The repository's doc-lint script explicitly allows those external-type/private-member diagnostics. This is an outstanding exception to the requested raw-lint-clean gate, not a claimed raw-lint pass.

## Follow-up

This is step 1 of the founder's tagged JSON decision. PR #131 will be rebased and widened after this PR merges. Merging and publication remain reserved for the founder.

## Closes

Closes #132
